### PR TITLE
Feed and coordinates

### DIFF
--- a/inkcut/core/api.py
+++ b/inkcut/core/api.py
@@ -9,7 +9,7 @@ Created on Dec 6, 2015
 
 @author: jrm
 """
-from .models import Model, Plugin, AreaBase
+from .models import Model, Plugin, AreaBase, PointF
 from .widgets import PickableDockArea as DockArea
 from .widgets import PickableDockItem as DockItem
 from .utils import from_unit, to_unit, unit_conversions, parse_unit

--- a/inkcut/core/models.py
+++ b/inkcut/core/models.py
@@ -166,6 +166,7 @@ class Plugin(EnamlPlugin):
         """ Unload any state observers when the plugin stops"""
         self._unbind_observers()
 
+    # TODO: get rid of this
     def run_command(self, protocol,  *args, **kwargs):
         """ Run a command without blocking using twisted's spawnProcess
 

--- a/inkcut/core/models.py
+++ b/inkcut/core/models.py
@@ -9,6 +9,7 @@ Created on Dec 6, 2017
 
 @author: jrm
 """
+import math
 import os
 import json
 import enaml
@@ -177,6 +178,48 @@ class AreaBase(Model):
     def available_area(self):
         return self.get_content_rect()
 
+    @staticmethod
+    def align_axis(o1: float, o2: float, b1: float, b2: float, side: int) -> float:
+        if side == AreaBase.JOB_AXIS_ALIGN_MIN:
+            return b1 - o1
+        if side == AreaBase.JOB_AXIS_ALIGN_MAX:
+            return b2 - o2
+        return (b1 + b2) / 2 - (o1 + o2) / 2
+
+    JOB_AXIS_ALIGN_ZERO = -2
+    JOB_AXIS_ALIGN_MIN = -1
+    JOB_AXIS_ALIGN_MID = 0
+    JOB_AXIS_ALIGN_MAX = 1
+
+    @staticmethod
+    def combine_alignment(x, y):
+        return ((x - AreaBase.JOB_AXIS_ALIGN_ZERO) << 4) + (y - AreaBase.JOB_AXIS_ALIGN_ZERO)
+
+    @staticmethod
+    def split_alignment(v):
+        x = (v >> 4) + AreaBase.JOB_AXIS_ALIGN_ZERO
+        y = (v & 3) + AreaBase.JOB_AXIS_ALIGN_ZERO
+        return x, y
+
+    @staticmethod
+    def align_rect_to_rect_combined(from_rect: QRectF, to_rect: QRectF, alignment_value,
+                                    forward_direction=QPointF(1, 1)) -> QTransform:
+        align_x, align_y = AreaBase.split_alignment(alignment_value)
+        return AreaBase.align_rect_to_rect(from_rect, to_rect,
+                                           align_x, align_y, forward_direction)
+
+    @staticmethod
+    def align_rect_to_rect(from_rect: QRectF, to_rect: QRectF, align_x, align_y,
+                           forward_direction=QPointF(1, 1)) -> QTransform:
+        if align_x == AreaBase.JOB_AXIS_ALIGN_ZERO:
+            align_x = 1 if forward_direction.x() < 0 else -1
+        if align_y == AreaBase.JOB_AXIS_ALIGN_ZERO:
+            align_y = 1 if forward_direction.y() < 0 else -1
+
+        dx = AreaBase.align_axis(from_rect.left(), from_rect.right(), to_rect.left(), to_rect.right(), align_x)
+        dy = AreaBase.align_axis(from_rect.top(), from_rect.bottom(), to_rect.top(), to_rect.bottom(), align_y)
+        return QTransform.fromTranslate(dx, dy)
+
 
 class PointF(Model):
     x = Float().tag(config=True)
@@ -184,6 +227,9 @@ class PointF(Model):
 
     def to_qt(self) -> QPointF:
         return QPointF(self.x, self.y)
+
+    def length(self):
+        return math.sqrt(self.x * self.x + self.y * self.y)
 
 
 class Plugin(EnamlPlugin):

--- a/inkcut/core/models.py
+++ b/inkcut/core/models.py
@@ -173,7 +173,8 @@ class AreaBase(Model):
         if not page_alignment:
             page_alignment = QPointF(1, 1)
         return self.get_rect(page_alignment, offset).adjusted(self.padding_left, self.padding_top,
-                                                      -self.padding_right, -self.padding_bottom)
+                                                              -self.padding_right, -self.padding_bottom)
+
     @property
     def available_area(self):
         return self.get_content_rect()

--- a/inkcut/core/svg.py
+++ b/inkcut/core/svg.py
@@ -724,6 +724,7 @@ class QtSvgDoc(QtSvgG):
                 self._nodes = valid_nodes
 
             self.viewBox = QRectF(0, 0, -1, -1)
+            self.document_size = None
         super(QtSvgDoc, self).__init__(e, self._nodes)
 
     def parseTransform(self, e):
@@ -747,7 +748,9 @@ class QtSvgDoc(QtSvgG):
                 outerWidth, outerHeight = map(self.parseUnit,
                                               (e.attrib.get('width', None),
                                                e.attrib.get('height', None)))
+
                 if outerWidth is not None and outerHeight is not None:
+                    self.document_size = QRectF(0, 0, outerWidth, outerHeight)
                     t.scale(outerWidth / innerWidth, outerHeight / innerHeight)
         else:
             x, y = map(self.parseUnit, (e.attrib.get('x', 0),

--- a/inkcut/core/utils.py
+++ b/inkcut/core/utils.py
@@ -247,6 +247,12 @@ def trailing_angle(path):
         return p.angleAtPercent(1)
 
 
+def rect_to_path(rect):
+    path = QPainterPath()
+    path.addRect(rect)
+    return path
+
+
 def find_subclasses(cls):
     """Finds all known (imported) subclasses of the given class"""
     cmds = []

--- a/inkcut/device/dialogs.enaml
+++ b/inkcut/device/dialogs.enaml
@@ -34,10 +34,15 @@ from inkcut.core.utils import to_unit, from_unit, load_icon
 
 enamldef ConfigEditView(Include):
     attr configurable: Model # Pair of config model and config declaration
-
+    attr plugin
     func load_config_view(config, declaration):
         View = declaration.config_view()
-        return [View(model=config)]
+        kwargs = {
+            'model': config
+        }
+        if plugin:
+            kwargs['plugin'] = plugin
+        return [View(**kwargs)]
     objects << load_config_view(configurable.config, configurable.declaration) \
         if configurable else [ConfigView(model=Model())]
 
@@ -81,8 +86,8 @@ enamldef DeviceEditView(Notebook): notebook:
                     text = QApplication.translate("device", "Width")
                 DoubleSpinBox:
                     enabled << cb.checked
-                    value << to_unit(device.area.size[0], units)
-                    value :: device.area.size[0] = from_unit(value, units)
+                    value << to_unit(device.config.area.size[0], units)
+                    value :: device.config.area.size[0] = from_unit(value, units)
                     suffix << " " + units
                     maximum = 99999.9
                     single_step = 0.1
@@ -90,8 +95,8 @@ enamldef DeviceEditView(Notebook): notebook:
                     text = QApplication.translate("device", "Length")
                 DoubleSpinBox:
                     enabled << cb.checked
-                    value << to_unit(device.area.size[1], units)
-                    value :: device.area.size[1] = from_unit(value, units)
+                    value << to_unit(device.config.area.size[1], units)
+                    value :: device.config.area.size[1] = from_unit(value, units)
                     suffix << " " + units
                     maximum = 99999.9
                     single_step = 0.1
@@ -103,6 +108,7 @@ enamldef DeviceEditView(Notebook): notebook:
         closable = False
         ConfigEditView:
             configurable << device
+            plugin << notebook.plugin
     Page:
         title = QApplication.translate("device", "Connection")
         closable = False

--- a/inkcut/device/drivers/manifest.enaml
+++ b/inkcut/device/drivers/manifest.enaml
@@ -7,6 +7,7 @@ from enaml.core.api import Include
 from enaml.workbench.plugin_manifest import PluginManifest
 from enaml.workbench.api import Extension
 from inkcut.device.extensions import DeviceDriver
+from inkcut.device.plugin import DeviceConfig
 
 
 def load_drivers():
@@ -67,7 +68,7 @@ enamldef DriversManifest(PluginManifest):
             width = '15in'
             protocols = ['hpgl']
             default_config = {
-              'swap_xy': True
+              'axis_mapping': DeviceConfig.AXIS_MAP_XD_YR
             }
 
         DeviceDriver:
@@ -76,7 +77,7 @@ enamldef DriversManifest(PluginManifest):
             width = '12in'
             protocols = ['hpgl']
             default_config = {
-              'swap_xy': True
+              'axis_mapping': DeviceConfig.AXIS_MAP_XD_YR
             }
 
         DeviceDriver:
@@ -85,7 +86,7 @@ enamldef DriversManifest(PluginManifest):
             width = '8in'
             protocols = ['hpgl']
             default_config = {
-              'swap_xy': True
+              'axis_mapping': DeviceConfig.AXIS_MAP_XD_YR
             }
 
         DeviceDriver:
@@ -144,10 +145,9 @@ enamldef DriversManifest(PluginManifest):
             protocols = ['gpgl']
             connections = ['printer']
             default_config = {
-              'scale': [ 5.64, 5.64 ],
-              'swap_xy': True,
-              'mirror_x': True,
-              'mirror_y': True
+              'axis_mapping': DeviceConfig.AXIS_MAP_XD_YR,
+              'extra_scale': DeviceConfig.to_scale_mul(20, 'step/mm'),
+              'protocol': { 'gpgl': { 'unit_mode': 0 }}
             }
 
         DeviceDriver:
@@ -158,7 +158,8 @@ enamldef DriversManifest(PluginManifest):
             protocols = ['gpgl']
             connections = ['printer']
             default_config = {
-              'scale': [ 5.64, 5.64 ]
+              'extra_scale': DeviceConfig.to_scale_mul(20, 'step/mm'),
+              'protocol': { 'gpgl': { 'unit_mode': 0 }}
             }
 
         DeviceDriver:

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -22,11 +22,11 @@ from enaml.qt import QtCore, QtGui
 from enaml.application import timed_call
 from inkcut.core.api import Model, Plugin, AreaBase
 from inkcut.core.utils import parse_unit, from_unit, to_unit, async_sleep, log
+from inkcut.job.models import Job
 from twisted.internet import defer
 from io import BytesIO
 from . import extensions
 import copy
-
 
 class DeviceError(AssertionError):
     """ Error for whatever """
@@ -579,10 +579,9 @@ class Device(Model):
         # device outputs
         model = job.create(swap_xy=config.swap_xy, scale=scale)
 
-        if job.feed_to_end:
-            #: Move the job to the new origin
-            x, y, z = self.origin
-            model.translate(x, -y)
+        #: Move the job to the new origin
+        x, y, z = self.origin
+        model.translate(x, -y)
 
         #: TODO: Apply filters here
 
@@ -872,7 +871,7 @@ class Device(Model):
                             yield defer.maybeDeferred(self.disconnect)
 
             #: Set the origin
-            if job.feed_to_end and job.info.status == 'complete':
+            if job.info.status == 'complete' and job.after_job == Job.FEED_TO_END:
                 self.origin = self.position
 
             #: If the user didn't cancel, set the origin and

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -33,6 +33,9 @@ from io import BytesIO
 from . import extensions
 import copy
 
+from ..core import utils
+
+
 class DeviceError(AssertionError):
     """ Error for whatever """
 
@@ -411,26 +414,12 @@ class DeviceConfig(Model):
             x1, x2, x3 = (self.extra_scale, 0, 0)
             y1, y2, y3 = (0, self.extra_scale, 0)
 
-            corner_alignment = self.expansion_direction
-
             if self.axis_mapping & DeviceConfig.AXIS_FLAG_H_LEFT:
                 x1 = -x1
-                #x3 = area.width()
-
             if self.axis_mapping & DeviceConfig.AXIS_FLAG_V_DOWN:
-                y1 = y1
+                y2 = y2
             else:
-                y1 = -y1
-            #if corner_alignment.y() > 0:
-            #    if reverse_v:
-            #        y1 = -y1
-            #    else:
-            #        y1 = y1
-            #else:
-            #    if reverse_v:
-            #        y1 = -y1
-            #    else:
-            #        y1 = y1
+                y2 = -y2
 
             if self.axis_mapping & DeviceConfig.AXIS_FLAG_SWAPXY:
                 x1, x2, x3, y1, y2, y3 = (y1, y2, y3, x1, x2, x3)
@@ -455,6 +444,7 @@ class DeviceConfig(Model):
             if invert_success:
                 self._inverse_transform = inverted
             else:
+                log.warn("failed to inverse trans")
                 self._inverse_transform = QTransform()
         return self._inverse_transform
 
@@ -739,10 +729,11 @@ class Device(Model):
         # device outputs
         model = job.create(direction)
 
-        tr = self.config.paper_to_work_transform(job.material)
+        tr = self.config.get_paper_to_work_transform(job.material)
         #: Move the job to the new origin
         x, y, z = self.origin
-        tr.translate(x, y)
+        origin = self.config.inverse_transform.map(QPointF(x, y))
+        tr.translate(origin.x(), origin.y())
         model = tr.map(model)
 
         #: Return the transformed model
@@ -1037,6 +1028,7 @@ class Device(Model):
             #: Set the origin
             if job.info.status == 'complete' and job.after_job == Job.FEED_TO_END:
                 self.origin = self.position
+                log.debug(f'update origin {self.origin}')
 
             #: If the user didn't cancel, set the origin and
             #: Process any jobs that entered the queue while this was running
@@ -1072,12 +1064,8 @@ class Device(Model):
         config = self.config
 
         # Previous point
-        _p = QtCore.QPointF(self.origin[0], self.origin[1])
 
-        # Do a final translation since Qt's y axis is reversed from svg's
-        # It should now be a bbox of (x=0, y=0, width, height)
-        # this creates a copy
-        model = QtGui.QTransform.fromScale(1, -1).map(model)
+        _p = self.config.inverse_transform.map(QtCore.QPointF(self.origin[0], self.origin[1]))
 
         # Determine if interpolation should be used
         skip_interpolation = (self.connection.always_spools or config.spooled
@@ -1427,39 +1415,34 @@ class DevicePlugin(Plugin):
         job = device.job
 
         if job:
-            job.set_direction(device.expansion_direction)
+            job.set_direction(device.config.expansion_direction,
+                              device.config.page_placement_direction)
 
         #: Transform used by the view
         preview_plugin = self.workbench.get_plugin('inkcut.preview')
         plot = preview_plugin.live_preview
         t = preview_plugin.transform
-        preview_plugin.set_live_preview(*view_items)
-
-
-        return # TODO: restore code
 
         #: Draw the device
-
-
-        r = QtGui.QTransform()
-
-        if device and device.area:
-            path = QPainterPath()
-            area = device.area_rect
-            path.addRect(area)
+        if device:
             view_items.append(
-                dict(path=r.map(t.map(path)),
+                dict(path=utils.rect_to_path(device.area_rect),
                      pen=plot.pen_device,
                      skip_autorange=True)
             )
 
         if job and job.material:
             # Also observe any change to job.media and job.device
+            page_rect = job.material.get_rect(job.quadrant_direction)
+            padded_page = job.material.get_content_rect(job.quadrant_direction)
+            t = device.config.get_paper_to_work_transform(job.material)
+            origin = device.config.inverse_transform.map(QPointF(device.origin[0], device.origin[1]))
+            t.translate(origin.x(), origin.y())
             view_items.extend([
-                dict(path=r.map(t.map(job.material.path)),
+                dict(path=utils.rect_to_path(t.mapRect(page_rect)),
                      pen=plot.pen_media,
                      skip_autorange=True),
-                dict(path=r.map(t.map(job.material.padding_path)),
+                dict(path=utils.rect_to_path(t.mapRect(padded_page)),
                      pen=plot.pen_media_padding, skip_autorange=True)
             ])
 
@@ -1471,5 +1454,7 @@ class DevicePlugin(Plugin):
         """ Watch the position of the device as it changes. """
         if change['type'] == 'update' and self.device.job:
             x, y, z = change['value']
+            origin = self.device.config.inverse_transform.map(QPointF(x, y))
+            x, y = origin.x(), origin.y()
             preview_plugin = self.workbench.get_plugin('inkcut.preview')
-            preview_plugin.live_preview.update(change['value'])
+            preview_plugin.live_preview.update((x, y, z))

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -1027,7 +1027,6 @@ class Device(Model):
             #: Set the origin
             if job.info.status == 'complete' and job.after_job == Job.FEED_TO_END:
                 self.origin = self.position
-                log.debug(f'update origin {self.origin}')
 
             #: If the user didn't cancel, set the origin and
             #: Process any jobs that entered the queue while this was running

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -218,6 +218,15 @@ class DeviceProtocol(Model):
         """
         pass
 
+    @property
+    def protocol_scale(self) -> Float:
+        """The scale for converting from inkcut units to protocol units.
+        The final scale is applied at protocol level, since some of the
+        protocols either define specific units or allow negotiating which
+        units to use.
+        """
+        return 1
+
 
 class DeviceFilter(Model):
     """ A device filter is applied to apply either the QPainterPath or to the

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -326,14 +326,14 @@ class DeviceConfig(Model):
 
     AXIS_MAP_MODES = {
         AXIS_MAP_XR_YU: QT_TRANSLATE_NOOP("device_axis", "X: right, Y: up"),
-        AXIS_MAP_XL_YU: QT_TRANSLATE_NOOP("device_axis", "X: left, Y: up"),
-        AXIS_MAP_XR_YD: QT_TRANSLATE_NOOP("device_axis", "X: right, Y: down"),
+        AXIS_MAP_XL_YU: QT_TRANSLATE_NOOP("device_axis", "X: left, Y: up (M)"),
+        AXIS_MAP_XR_YD: QT_TRANSLATE_NOOP("device_axis", "X: right, Y: down (M)"),
         AXIS_MAP_XL_YD: QT_TRANSLATE_NOOP("device_axis", "X: left, Y: down"),
 
-        AXIS_MAP_XU_YR: QT_TRANSLATE_NOOP("device_axis", "X: up, Y: right"),
+        AXIS_MAP_XU_YR: QT_TRANSLATE_NOOP("device_axis", "X: up, Y: right (M)"),
         AXIS_MAP_XD_YR: QT_TRANSLATE_NOOP("device_axis", "X: down, Y: right"),
         AXIS_MAP_XU_YL: QT_TRANSLATE_NOOP("device_axis", "X: up, Y: left"),
-        AXIS_MAP_XD_YL: QT_TRANSLATE_NOOP("device_axis", "X: down, Y: left"),
+        AXIS_MAP_XD_YL: QT_TRANSLATE_NOOP("device_axis", "X: down, Y: left (M)"),
 
         AXIS_MAP_CUSTOM: QT_TRANSLATE_NOOP("device_axis", "Custom"),
     }

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -10,11 +10,8 @@ Created on Jan 16, 2015
 
 @author: jrm
 """
-from typing import Optional
-
 import enaml
 import traceback
-
 from atom.api import (
     Typed, List, Instance, ForwardInstance, ContainerList, Bool, Str,
     Int, Float, Enum, Bytes, observe
@@ -28,12 +25,11 @@ from enaml.application import timed_call
 from inkcut.core.api import Model, Plugin, AreaBase, PointF
 from inkcut.core.utils import parse_unit, from_unit, to_unit, async_sleep, log
 from inkcut.job.models import Job
+from typing import Optional
 from twisted.internet import defer
 from io import BytesIO
 from . import extensions
 import copy
-
-from ..core import utils
 
 
 class DeviceError(AssertionError):
@@ -300,10 +296,6 @@ class DeviceConfig(Model):
     #: set this to a high number like 2000 or 3000
     sample_rate = Int(100).tag(config=True)
 
-    #: Final output rotation
-    rotation = Enum(0, 90, -90).tag(config=True)
-
-
     area = Instance(AreaBase).tag(config=True)
 
     AXIS_FLAG_H_LEFT = 1
@@ -349,7 +341,7 @@ class DeviceConfig(Model):
         config=True)
     paper_offset = Instance(PointF, args=()).tag(config=True)
 
-    extra_scale : Float = Float(1.0).tag(config=True)
+    extra_scale: Float = Float(1.0).tag(config=True)
     custom_mapping = ContainerList(Float(strict=False), default=[1, 0, 0, 0, 1, 0]).tag(config=True)
 
     #: Defines prescaling before conversion to a polygon
@@ -381,8 +373,8 @@ class DeviceConfig(Model):
     commands_connect = Str().tag(config=True)
     commands_disconnect = Str().tag(config=True)
 
-    _transform: Optional[QTransform] #= Instance(QTransform, optional=True)
-    _inverse_transform: Optional[QTransform]  # = Instance(QTransform, optional=True)
+    _transform: Optional[QTransform]
+    _inverse_transform: Optional[QTransform]
 
     def _default_step_time(self):
         """ Determine the step time based on the device speed setting
@@ -397,7 +389,7 @@ class DeviceConfig(Model):
             return 0
 
         #: No determine the time and convert to ms
-        return max(0, round(1000*self.step_size/speed))
+        return max(0, round(1000 * self.step_size / speed))
 
     def _default_area(self):
         return AreaBase()
@@ -434,11 +426,13 @@ class DeviceConfig(Model):
     def refresh_transform(self, change):
         self._transform = None
         self._inverse_transform = None
+
     @property
     def transform(self):
         if self._transform is None:
             self._transform = self.make_transform(self.area)
         return self._transform
+
     @property
     def inverse_transform(self):
         if not self._inverse_transform:
@@ -449,7 +443,6 @@ class DeviceConfig(Model):
                 log.warn("failed to inverse trans")
                 self._inverse_transform = QTransform()
         return self._inverse_transform
-
 
     @staticmethod
     def corner_to_rect_direction(corner):
@@ -462,6 +455,7 @@ class DeviceConfig(Model):
         elif corner == DeviceConfig.ALIGNMENT_CORNER_TOP_RIGHT:
             return QPointF(-1, 1)
         ValueError("Unexpected corner {}".format(corner))
+
     @property
     def expansion_direction(self) -> QPointF:
         if self.area_alignment_corner == DeviceConfig.ALIGNMENT_CORNER_ZERO:
@@ -474,6 +468,7 @@ class DeviceConfig(Model):
                 direction.setX(-1)
             return direction
         return DeviceConfig.corner_to_rect_direction(self.area_alignment_corner)
+
     @property
     def working_area_rect(self) -> QRectF:
         return self.area.get_rect(self.expansion_direction, self.work_area_offset.to_qt())
@@ -513,6 +508,7 @@ class DeviceConfig(Model):
             return to_unit(1, "in") / v
         return v
 
+
 class Device(Model):
     """ The standard device. This is a standard model used throughout the
     application. An instance of this is configured by specifying a
@@ -544,7 +540,7 @@ class Device(Model):
     connection = Instance(DeviceTransport).tag(config=True)
 
     #: List of jobs that were run on this device
-    jobs = List(Model)#.tag(config=True)
+    jobs = List(Model).tag(config=True)
 
     #: List of jobs queued to run on this device
     queue = List(Model).tag(config=True)
@@ -581,7 +577,6 @@ class Device(Model):
         if not h:
             h = 900000
         self.config.area.size[1] = h
-
 
     def _default_connection(self):
         """ If no connection is set when the device is created,

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -349,8 +349,8 @@ class DeviceConfig(Model):
     area_alignment_corner = Enum(ALIGNMENT_CORNER_ZERO, ALIGNMENT_CORNER_TOP_LEFT, ALIGNMENT_CORNER_TOP_RIGHT,
                                  ALIGNMENT_CORNER_BOTTOM_LEFT, ALIGNMENT_CORNER_BOTTOM_RIGHT).tag(config=True)
     work_area_offset = Instance(PointF, args=()).tag(config=True)
-    paper_corner = Enum(ALIGNMENT_CORNER_ZERO, ALIGNMENT_CORNER_TOP_LEFT, ALIGNMENT_CORNER_TOP_RIGHT,
-                            ALIGNMENT_CORNER_BOTTOM_LEFT, ALIGNMENT_CORNER_BOTTOM_RIGHT).tag(config=True)
+    paper_corner = Int(AreaBase.combine_alignment(AreaBase.JOB_AXIS_ALIGN_ZERO, AreaBase.JOB_AXIS_ALIGN_ZERO)).tag(
+        config=True)
     paper_offset = Instance(PointF, args=()).tag(config=True)
 
     extra_scale : Float = Float(1.0).tag(config=True)
@@ -481,13 +481,6 @@ class DeviceConfig(Model):
                 direction.setX(-1)
             return direction
         return DeviceConfig.corner_to_rect_direction(self.area_alignment_corner)
-
-    @property
-    def page_placement_direction(self) -> QPointF:
-        if self.paper_corner == DeviceConfig.ALIGNMENT_CORNER_ZERO:
-            return self.expansion_direction
-        return DeviceConfig.corner_to_rect_direction(self.paper_corner)
-
     @property
     def working_area_rect(self) -> QRectF:
         return self.area.get_rect(self.expansion_direction, self.work_area_offset.to_qt())
@@ -499,7 +492,9 @@ class DeviceConfig(Model):
     def get_paper_to_work_transform(self, paper_area: AreaBase):
         work_area = self.working_area_rect
         paper = paper_area.get_rect(self.expansion_direction)
-        return AreaBase.align_rect(paper, work_area, self.page_placement_direction, self.paper_offset.to_qt())
+        return AreaBase.align_rect_to_rect_combined(paper, work_area, self.paper_corner,
+                                                    self.expansion_direction).translate(self.paper_offset.x,
+                                                                                        self.paper_offset.y)
 
 
 class Device(Model):

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -447,7 +447,7 @@ class DeviceConfig(Model):
     def transform(self):
         if self._transform is None:
             self._transform = self.make_transform(self.area)
-        return self.transform
+        return self._transform
     @property
     def inverse_transform(self):
         if not self._inverse_transform:

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -429,8 +429,8 @@ class DeviceConfig(Model):
                               x2, y2,
                               x3, y3)
 
-
-    @observe('area', 'axis_mapping', 'area_alignment_corner')
+    @observe('area', 'axis_mapping', 'area_alignment_corner',
+             'work_area_offset', 'paper_corner', 'paper_offset', 'extra_scale', 'custom_mapping')
     def refresh_transform(self, change):
         self._transform = None
         self._inverse_transform = None

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -303,10 +303,6 @@ class DeviceConfig(Model):
     #: Final output rotation
     rotation = Enum(0, 90, -90).tag(config=True)
 
-    #: Swap x and y axis
-    swap_xy = Bool().tag(config=True)
-    mirror_y = Bool().tag(config=True)
-    mirror_x = Bool().tag(config=True)
 
     area = Instance(AreaBase).tag(config=True)
 
@@ -355,9 +351,6 @@ class DeviceConfig(Model):
 
     extra_scale : Float = Float(1.0).tag(config=True)
     custom_mapping = ContainerList(Float(strict=False), default=[1, 0, 0, 0, 1, 0]).tag(config=True)
-
-    #: Final out scaling
-    scale = ContainerList(Float(strict=False), default=[1, 1]).tag(config=True)
 
     #: Defines prescaling before conversion to a polygon
     quality_factor = Float(1, strict=False).tag(config=True)
@@ -496,6 +489,29 @@ class DeviceConfig(Model):
                                                     self.expansion_direction).translate(self.paper_offset.x,
                                                                                         self.paper_offset.y)
 
+    @staticmethod
+    def from_scale_mul(v, unit):
+        if unit == "step/in":
+            return v * from_unit(1, "in")
+        elif unit == "step/mm":
+            return v * from_unit(1, "mm")
+        elif unit == "mm/step":
+            return to_unit(1, "mm") / v
+        elif unit == "in/step":
+            return to_unit(1, "in") / v
+        return v
+
+    @staticmethod
+    def to_scale_mul(v, unit):
+        if unit == "step/in":
+            return to_unit(v, "in")
+        elif unit == "step/mm":
+            return to_unit(v, "mm")
+        elif unit == "mm/step":
+            return to_unit(1, "mm") / v
+        elif unit == "in/step":
+            return to_unit(1, "in") / v
+        return v
 
 class Device(Model):
     """ The standard device. This is a standard model used throughout the
@@ -669,39 +685,6 @@ class Device(Model):
             new_dev.connection.config = copy.deepcopy(self.connection.config)
 
         return new_dev
-
-    def transform_tmp(self, path):
-        """ Apply the device output transform to the given path. This
-        is used by other plugins that may need to display or work with
-        tranformed output.
-
-        Parameters
-        ----------
-            path: QPainterPath
-                Path to transform
-
-        Returns
-        -------
-            path: QPainterPath
-
-        """
-        config = self.config
-
-        t = QtGui.QTransform()
-
-        #: Order matters!
-        if config.scale:
-            #: Do final output scaling
-            t.scale(*config.scale)
-
-        if config.rotation:
-            #: Do final output rotation
-            t.rotate(config.rotation)
-
-        #: TODO: Translate back to 0,0 so all coordinates are positive
-        path = t.map(path)
-
-        return path
 
     def init(self, job):
         """ Initialize the job. This should do any final path manipulation

--- a/inkcut/device/plugin.py
+++ b/inkcut/device/plugin.py
@@ -537,10 +537,12 @@ class Device(Model):
 
     #: Position. Defaults to x,y,z. The protocol can
     #: handle this however necessary.
+    # device coordinate space, inkcut working units
     position = ContainerList(default=[0, 0, 0])
 
     #: Origin position. Defaults to [0, 0, 0]. The system will translate
     #: jobs to the origin so multiple can be run.
+    # device coordinate space, inkcut working units
     origin = ContainerList(default=[0, 0, 0])
 
     #: Device is currently busy processing a job
@@ -782,18 +784,15 @@ class Device(Model):
         p = QPointF(position[0], position[1])
 
         if absolute:
-            #: Clip everything to never go below zero in absolute mode
             p = self.map_point(p)
             position = [p.x(), p.y(), position[2]]
             self.position = position
         else:
-            #: Convert to relative to absolute for the UI
-            p += QPointF(position[0], position[1])
-            p = self.map_point(p)
-            position = [p.x(), p.y(), position[2]]
+            p = self.map_vector(p)
+            position = [self.position[0] + p.x(), self.position[1] + p.y(), position[2]]
             self.position = position
 
-        #TODO: use relative mode provided by protocol and self.map_vector
+        # TODO: use relative mode provided by protocol and self.map_vector
         result = self.connection.protocol.move(*position, absolute=absolute)
         if result:
             return result
@@ -1400,54 +1399,20 @@ class DevicePlugin(Plugin):
     # -------------------------------------------------------------------------
     # Live progress API
     # -------------------------------------------------------------------------
-    def reset_preview(self):
-        """ Clear the preview """
-        self._reset_preview(None)
 
-    @observe('device', 'device.job', 'device.alignment_corner', 'device.area')
+    @observe('device', 'device.job', 'device.alignment_corner', 'device.paper_corner', 'device.area')
     def _reset_preview(self, change):
-        """ Redraw the preview on the screen
-
-        """
-        view_items = []
-
-        device = self.device
-        job = device.job
-
-        if job:
-            job.set_direction(device.config.expansion_direction,
-                              device.config.page_placement_direction)
-
-        #: Transform used by the view
+        # TODO: device plugin shouldn't need to know anything about preview plugin, preview plugin should subscribe to
+        # relevant events itself
         preview_plugin = self.workbench.get_plugin('inkcut.preview')
-        plot = preview_plugin.live_preview
-        t = preview_plugin.transform
+        preview_plugin.reset_live_preview(self.device, self.device.job, clear_paths=True)
 
-        #: Draw the device
-        if device:
-            view_items.append(
-                dict(path=utils.rect_to_path(device.area_rect),
-                     pen=plot.pen_device,
-                     skip_autorange=True)
-            )
-
-        if job and job.material:
-            # Also observe any change to job.media and job.device
-            page_rect = job.material.get_rect(job.quadrant_direction)
-            padded_page = job.material.get_content_rect(job.quadrant_direction)
-            t = device.config.get_paper_to_work_transform(job.material)
-            origin = device.config.inverse_transform.map(QPointF(device.origin[0], device.origin[1]))
-            t.translate(origin.x(), origin.y())
-            view_items.extend([
-                dict(path=utils.rect_to_path(t.mapRect(page_rect)),
-                     pen=plot.pen_media,
-                     skip_autorange=True),
-                dict(path=utils.rect_to_path(t.mapRect(padded_page)),
-                     pen=plot.pen_media_padding, skip_autorange=True)
-            ])
-
-        #: Update the plot
-        preview_plugin.set_live_preview(*view_items)
+    @observe('device.origin')
+    def _reset_preview2(self, change):
+        # TODO: device plugin shouldn't need to know anything about preview plugin, preview plugin should subscribe to
+        # relevant events itself
+        preview_plugin = self.workbench.get_plugin('inkcut.preview')
+        preview_plugin.reset_live_preview(self.device, self.device.job, clear_paths=False)
 
     @observe('device.position')
     def _update_preview(self, change):

--- a/inkcut/device/protocols/camm.py
+++ b/inkcut/device/protocols/camm.py
@@ -8,6 +8,7 @@ from inkcut.device.plugin import DeviceProtocol
 
 
 class CAMMGL1Protocol(DeviceProtocol):
+    # Needs to be Rechecked and potentially renamed. Contains potentially incorrect mix of mode 1 and mode 2 commands.
     def connection_made(self):
         self.write("IN;")
     
@@ -25,3 +26,7 @@ class CAMMGL1Protocol(DeviceProtocol):
 
     def connection_lost(self):
         pass
+
+    @property
+    def protocol_scale(self):
+        return 1

--- a/inkcut/device/protocols/debug.py
+++ b/inkcut/device/protocols/debug.py
@@ -32,3 +32,7 @@ class DebugProtocol(DeviceProtocol):
 
     def connection_lost(self):
         log.debug("protocol.connection_lost()")
+
+    @property
+    def protocol_scale(self):
+        return 1

--- a/inkcut/device/protocols/dmpl.py
+++ b/inkcut/device/protocols/dmpl.py
@@ -22,7 +22,7 @@ class DMPLConfig(Model):
     SCALE_1_MM = 3
     SCALE_025_MM = 4
 
-    #TODO: LOOK into EC0.
+    # TODO: LOOK into EC0.
     SCALE_MAPPING = {
         SCALE_IGNORE: "",
         SCALE_001_IN: "EC1",
@@ -55,7 +55,7 @@ class DMPLProtocol(DeviceProtocol):
 
     def move(self, x, y, z, absolute=True):
         scale = self.protocol_scale()
-        x, y = int(x*scale), int(y*scale)
+        x, y = int(x * scale), int(y * scale)
         v = self.config.mode
         self.write(" {z}{x},{y} ".format(x=x, y=y, z=z and "D" or "U"))
 

--- a/inkcut/device/protocols/dmpl.py
+++ b/inkcut/device/protocols/dmpl.py
@@ -8,12 +8,30 @@ Thanks to Lex Wernars
 @author: lwernars
 """
 from atom.api import Enum, Instance, Float
+
+from inkcut.core.utils import to_unit
 from inkcut.device.plugin import DeviceProtocol, Model
 
 
 class DMPLConfig(Model):
     #: Version number
-    mode = Enum(1, 2, 3, 4, 6).tag(config=True)
+    mode = Enum(1, 2, 3, 4).tag(config=True)
+    SCALE_IGNORE = 0
+    SCALE_001_IN = 1
+    SCALE_005_IN = 2
+    SCALE_1_MM = 3
+    SCALE_025_MM = 4
+
+    #TODO: LOOK into EC0.
+    SCALE_MAPPING = {
+        SCALE_IGNORE: "",
+        SCALE_001_IN: "EC1",
+        SCALE_005_IN: "EC5",
+        SCALE_1_MM: "ECM",
+        SCALE_025_MM: "ECN",
+    }
+
+    unit_mode = Enum(SCALE_025_MM, SCALE_1_MM, SCALE_005_IN, SCALE_001_IN, SCALE_IGNORE).tag(config=True)
 
 
 class DMPLProtocol(DeviceProtocol):
@@ -21,33 +39,48 @@ class DMPLProtocol(DeviceProtocol):
     #: Different modes
     config = Instance(DMPLConfig, ()).tag(config=True)
 
-    #: Output scaling
-    scale = Float(1021/90.0)
+    def get_scale_cmd(self):
+        return DMPLConfig.SCALE_MAPPING.get(self.config.unit_mode, "")
 
     def connection_made(self):
         v = self.config.mode
+
+        scale_cmd = self.get_scale_cmd()
         if v == 1:
-            self.write(";:HAEC1")
+            self.write(";:HA{}".format(scale_cmd))
         elif v == 2:
-            self.write(" ;:ECN A L0 ")
+            self.write(" ;:{} A L0 ".format(scale_cmd))
         elif v in [3, 4]:
             self.write(" ;:H A L0 ")
-        elif v == 6:
-            self.write("IN;PA;")
 
     def move(self, x, y, z, absolute=True):
-        x, y = int(x*self.scale), int(y*self.scale)
+        scale = self.protocol_scale()
+        x, y = int(x*scale), int(y*scale)
         v = self.config.mode
-        if v in [1, 2, 3, 4]:
-            self.write(" {z}{x},{y} ".format(x=x, y=y, z=z and "D" or "U"))
+        self.write(" {z}{x},{y} ".format(x=x, y=y, z=z and "D" or "U"))
+
+    @property
+    def protocol_scale(self):
+        if self.config.unit_mode == DMPLProtocol.SCALE_001_IN:
+            return 1000 / 90.0
+        elif self.config.unit_mode == DMPLProtocol.SCALE_005_IN:
+            return 200 / 90.0
+        if self.config.unit_mode == DMPLProtocol.SCALE_1_MM:
+            return 10 * 25.4 / 90.0
+        elif self.config.unit_mode == DMPLProtocol.SCALE_025MM:
+            return 40 * 25.4 / 90.0
         else:
-            self.write("{z}{x},{y};".format(x=x, y=y, z=z and "PD" or "PU"))
+            return 1
 
     def set_pen(self, p):
-        self.write("EC{p} ".format(p=p))
+        self.write("P{p} ".format(p=p))
 
     def set_velocity(self, v):
-        self.write("V{v} ".format(v=v))
+        if self.config.scale_mode == DMPLConfig.SCALE_001_IN or self.config.scale_mode == DMPLConfig.SCALE_005_IN:
+            v = to_unit(v, "in")
+        else:
+            v = to_unit(v, "cm")
+        self.write("V{v:.0f} ".format(v=v))
 
     def set_force(self, f):
         self.write("BP{f} ".format(f=f))

--- a/inkcut/device/protocols/gcode.py
+++ b/inkcut/device/protocols/gcode.py
@@ -7,8 +7,9 @@ Created on Dec 30, 2016
 import atom.api
 import twisted.internet.task
 
-from inkcut.core.utils import async_sleep
+from inkcut.core.utils import async_sleep, log
 from inkcut.device.plugin import DeviceProtocol, Model
+from inkcut.core.api import from_unit, to_unit
 from twisted.internet import defer
 from enaml.qt.QtCore import QT_TRANSLATE_NOOP
 from atom.api import Bool, Float, Enum, Int, Instance, Str, Bytes
@@ -47,20 +48,24 @@ class GCodeConfig(Model):
 
     stream_mode = Enum(*GCODE_STREAM_MODES.keys()).tag(config=True)
 
+    UNIT_METRIC = 21
+    UNIT_INCH = 20
+
+    unit_mode = Enum(UNIT_METRIC, UNIT_INCH).tag(config=True)
+
 
 class GCodeProtocol(DeviceProtocol):
 
     config = Instance(GCodeConfig, ()).tag(config=True)
 
     _currently_up = Bool()
-    scale = 1  # Float(25.4/90)
+    scale = Float(25.4/90)
     _ok_waiting = Int(default=0)
     _receive_buffer = Bytes()
     _reactor = atom.api.Value()
 
     def _default__reactor(self):
         from twisted.internet import reactor as reactor
-
         return reactor
 
     def non_interactive_streaming(self):
@@ -78,7 +83,7 @@ class GCodeProtocol(DeviceProtocol):
             elif stream_mode == GCodeConfig.GCODE_STREAM_OK:
                 yield defer.maybeDeferred(self._send_stream_simple_ok, commands)
             else:
-                logging.debug("Unexpected streaming mode")
+                log.warn("Unexpected streaming mode")
 
     @defer.inlineCallbacks
     def send_command_block(self, commands):
@@ -149,11 +154,16 @@ class GCodeProtocol(DeviceProtocol):
     @defer.inlineCallbacks
     def connection_made(self):
         self._ok_waiting = 0
+        if self.config.unit_mode == GCodeConfig.UNIT_INCH:
+            self.scale = to_unit(1, 'in')
+        else:
+            self.scale = to_unit(1, 'mm')
         if self.config.use_builtin:
             yield self.write(
                 "G28; Return to home\n"
                 + "G98; Return to initial z\n"
                 + "G90; Use absolute coordinates\n"
+                + ("G21\n" if self.config.unit_mode == GCodeConfig.UNIT_METRIC else "G20\n")
             )
 
     @defer.inlineCallbacks

--- a/inkcut/device/protocols/gcode.py
+++ b/inkcut/device/protocols/gcode.py
@@ -55,11 +55,10 @@ class GCodeConfig(Model):
 
 
 class GCodeProtocol(DeviceProtocol):
-
     config = Instance(GCodeConfig, ()).tag(config=True)
 
     _currently_up = Bool()
-    scale = Float(25.4/90)
+    scale = Float(25.4 / 90)
     _ok_waiting = Int(default=0)
     _receive_buffer = Bytes()
     _reactor = atom.api.Value()

--- a/inkcut/device/protocols/gcode.py
+++ b/inkcut/device/protocols/gcode.py
@@ -151,13 +151,17 @@ class GCodeProtocol(DeviceProtocol):
         if self.config.lift_mode == GCodeConfig.TOOL_LIFT_CUSTOM:
             yield self.send_command_block(self.config.lower_gcode)
 
+    @property
+    def protocol_scale(self) -> Float:
+        if self.config.unit_mode == GCodeConfig.UNIT_METRIC:
+            return to_unit(1, 'mm')
+        else:
+            return to_unit(1, 'in')
+
     @defer.inlineCallbacks
     def connection_made(self):
         self._ok_waiting = 0
-        if self.config.unit_mode == GCodeConfig.UNIT_INCH:
-            self.scale = to_unit(1, 'in')
-        else:
-            self.scale = to_unit(1, 'mm')
+        self.scale = self.protocol_scale
         if self.config.use_builtin:
             yield self.write(
                 "G28; Return to home\n"

--- a/inkcut/device/protocols/gpgl.py
+++ b/inkcut/device/protocols/gpgl.py
@@ -15,8 +15,8 @@ from inkcut.device.plugin import DeviceProtocol, Model
 
 class GPGLConfig(Model):
     SCALE_IGNORE = 0
-    SCALE_1MM = 1 # 0.1mm
-    SCALE_025MM = 2 # 0.025mm
+    SCALE_1MM = 1  # 0.1mm
+    SCALE_025MM = 2  # 0.025mm
 
     unit_mode = Enum(SCALE_025MM, SCALE_1MM, SCALE_IGNORE).tag(config=True)
 
@@ -34,7 +34,7 @@ class GPGLProtocol(DeviceProtocol):
         x = round(x)
         y = round(y)
         if absolute:
-            self.write("%s%i,%i"%('D' if z else 'M', x, y))
+            self.write("%s%i,%i" % ('D' if z else 'M', x, y))
         else:
             self.write("%s%i,%i" % ('E' if z else 'O', x, y))
 

--- a/inkcut/device/protocols/gpgl.py
+++ b/inkcut/device/protocols/gpgl.py
@@ -7,15 +7,36 @@ Thanks to Lex Wernars
 @author: jrm
 @author: lwernars
 """
+
 from inkcut.device.plugin import DeviceProtocol
+from atom.api import Instance, Float, Bool, Int, Enum
+from inkcut.device.plugin import DeviceProtocol, Model
+
+
+class GPGLConfig(Model):
+    SCALE_IGNORE = 0
+    SCALE_1MM = 1 # 0.1mm
+    SCALE_025MM = 2 # 0.025mm
+
+    unit_mode = Enum(SCALE_025MM, SCALE_1MM, SCALE_IGNORE).tag(config=True)
 
 
 class GPGLProtocol(DeviceProtocol):
+    config = Instance(GPGLConfig, ()).tag(config=True)
+
     def connection_made(self):
         self.write("H")
 
     def move(self, x, y, z, absolute=True):
-        self.write("%s%i,%i"%('D' if z else 'M', x, y))
+        scale = self.protocol_scale
+        x *= scale
+        y *= scale
+        x = round(x)
+        y = round(y)
+        if absolute:
+            self.write("%s%i,%i"%('D' if z else 'M', x, y))
+        else:
+            self.write("%s%i,%i" % ('E' if z else 'O', x, y))
 
     def set_velocity(self, v):
         self.write('!%i' % v)
@@ -25,3 +46,12 @@ class GPGLProtocol(DeviceProtocol):
 
     def set_pen(self, p):
         pass
+
+    @property
+    def protocol_scale(self):
+        if self.config.unit_mode == GPGLConfig.SCALE_025MM:
+            return 40 * 25.4 / 90.0
+        elif self.config.unit_mode == GPGLConfig.SCALE_1MM:
+            return 10 * 25.4 / 90.0
+        else:
+            return 1

--- a/inkcut/device/protocols/hpgl.py
+++ b/inkcut/device/protocols/hpgl.py
@@ -45,13 +45,13 @@ class HPGLProtocol(DeviceProtocol):
 
     def set_force(self, f):
         self.write("FS%i; " % f)
-        
+
     def set_velocity(self, v):
         self.write("VS%i;" % v)
-        
+
     def set_pen(self, p):
         self.write("SP%i;" % p)
-        
+
     def finish(self):
         # Reinitialize
         self.write("IN;")

--- a/inkcut/device/protocols/hpgl.py
+++ b/inkcut/device/protocols/hpgl.py
@@ -12,10 +12,11 @@ from inkcut.core.utils import log
 class HPGLConfig(Model):
     #: Pad option
     pad = Bool().tag(config=True)
+    ignore_protocol_scale = Bool(False).tag(config=True)
 
 
 class HPGLProtocol(DeviceProtocol):
-    scale = Float(1021/90.0)
+    DEFAULT_SCALE = Float(1016 / 90.0)
 
     #: Pad option
     config = Instance(HPGLConfig, ()).tag(config=True)
@@ -35,7 +36,8 @@ class HPGLProtocol(DeviceProtocol):
         negative values so absolute moves only works.
         
         """
-        x, y = int(x*self.scale), int(y*self.scale)
+        scale = self.protocol_scale
+        x, y = int(x * scale), int(y * scale)
         if absolute:
             self.write("%s%i,%i;" % ('PD' if z else 'PU', x, y))
         else:
@@ -54,3 +56,8 @@ class HPGLProtocol(DeviceProtocol):
         # Reinitialize
         self.write("IN;")
 
+    @property
+    def protocol_scale(self):
+        if self.config.ignore_protocol_scale:
+            return 1
+        return HPGLProtocol.DEFAULT_SCALE

--- a/inkcut/device/protocols/manifest.enaml
+++ b/inkcut/device/protocols/manifest.enaml
@@ -37,6 +37,11 @@ def hpgl_config_view():
         from .view import HPGLConfigView
     return HPGLConfigView
 
+def gpgl_config_view():
+    with enaml.imports():
+        from .view import GPGLConfigView
+    return GPGLConfigView
+
 
 def cammgl1_factory(driver, declaration):
     from .camm import CAMMGL1Protocol
@@ -74,6 +79,7 @@ enamldef ProtocolManifest(PluginManifest):
             id = 'gpgl'
             name = 'GPGL'
             factory = gpgl_factory
+            config_view = gpgl_config_view
 
         DeviceProtocol:
             id = 'hpgl'

--- a/inkcut/device/protocols/manifest.enaml
+++ b/inkcut/device/protocols/manifest.enaml
@@ -11,13 +11,15 @@ from inkcut.device.extensions import DEVICE_PROTOCOL_POINT, DeviceProtocol
 
 
 def gpgl_factory(driver, declaration):
-    from .gpgl import GPGLProtocol
-    return GPGLProtocol(declaration=declaration)
+    from .gpgl import GPGLProtocol, GPGLConfig
+    return GPGLProtocol(declaration=declaration,
+                        config=GPGLConfig(**driver.get_protocol_config('gpgl')))
 
 
 def hpgl_factory(driver, declaration):
     from .hpgl import HPGLProtocol
-    return HPGLProtocol(declaration=declaration)
+    return HPGLProtocol(declaration=declaration,
+                        config=GPGLConfig(**driver.get_protocol_config('hpgl')))
 
 
 def dmpl_factory(driver, declaration):

--- a/inkcut/device/protocols/manifest.enaml
+++ b/inkcut/device/protocols/manifest.enaml
@@ -17,9 +17,9 @@ def gpgl_factory(driver, declaration):
 
 
 def hpgl_factory(driver, declaration):
-    from .hpgl import HPGLProtocol
+    from .hpgl import HPGLProtocol, HPGLConfig
     return HPGLProtocol(declaration=declaration,
-                        config=GPGLConfig(**driver.get_protocol_config('hpgl')))
+                        config=HPGLConfig(**driver.get_protocol_config('hpgl')))
 
 
 def dmpl_factory(driver, declaration):

--- a/inkcut/device/protocols/view.enaml
+++ b/inkcut/device/protocols/view.enaml
@@ -16,6 +16,8 @@ from enamlx.widgets.api import DoubleSpinBox
 from enaml.qt.QtWidgets import QApplication
 from enaml.qt.QtCore import QT_TRANSLATE_NOOP
 from .gcode import GCodeConfig
+from .gpgl import GPGLConfig
+from .dmpl import DMPLConfig
 
 enamldef DMPLConfigView(Container):
     attr model
@@ -53,7 +55,7 @@ enamldef GCodeConfigView(Container):
             maximum = 10
         Label:
             text = QApplication.translate("protocols", "Streaming mode")
-            tool_tip = QApplication.translate("protocols", "None - no audtional stream flow control, ok - wait for ok response after each command (recommended for Marlin and Grbl).")
+            tool_tip = QApplication.translate("protocols", "None - no additional stream flow control, ok - wait for ok response after each command (recommended for Marlin and Grbl).")
         ObjectCombo:
             items = list(GCodeConfig.GCODE_STREAM_MODES.items())
             to_string = lambda obj: QApplication.translate("gcode", obj[1])
@@ -113,13 +115,48 @@ enamldef DMPLConfigView(Container):
     ObjectCombo:
         items  = list(model.get_member('mode').items)
         selected := model.mode
+    Label:
+        text = QApplication.translate("protocols", "Protocol scale")
+    ObjectCombo:
+        attr labels = {
+            DMPLConfig.SCALE_IGNORE: QT_TRANSLATE_NOOP("protocols", "Ignore"),
+            DMPLConfig.SCALE_001_IN: QT_TRANSLATE_NOOP("protocols", "0.001 in/step EC1"),
+            DMPLConfig.SCALE_005_IN: QT_TRANSLATE_NOOP("protocols", "0.005 in/step EC5"),
+            DMPLConfig.SCALE_1_MM: QT_TRANSLATE_NOOP("protocols", "0.1 mm/step ECM"),
+            DMPLConfig.SCALE_025_MM: QT_TRANSLATE_NOOP("protocols", "0.025 mm/step ECN"),
+        }
+        to_string = lambda v: QApplication.translate('protocols', labels[v])
+        items = list(labels.keys())
+        selected := model.unit_mode
 
 
 enamldef HPGLConfigView(Container):
     attr model
     Label:
-        text = QApplication.translate("protocols",
-                                      "Pad commands with line feed")
+        pass
     CheckBox:
         checked := model.pad
-        text = QApplication.translate("protocols", "Enable")
+        text = QApplication.translate("protocols",
+                                      "Pad commands with line feed")
+    Label:
+        pass
+    CheckBox:
+        checked := model.ignore_protocol_scale
+        text = QApplication.translate("protocols",
+                                      "Ignore protocol scale")
+        tool_tip = QApplication.translate("protocols",
+          "Do not apply the default protocol scale (0.025mm=1/1016in). Enable this if you are going to apply custom scale in Device/Output settings.")
+
+enamldef GPGLConfigView(Container):
+    attr model
+    Label:
+        text = QApplication.translate("protocols", "Protocol scale")
+    ObjectCombo:
+        attr labels = {
+            GPGLConfig.SCALE_IGNORE: QT_TRANSLATE_NOOP("protocols", "Ignore"),
+            GPGLConfig.SCALE_1MM: QT_TRANSLATE_NOOP("protocols", "0.1mm/step"),
+            GPGLConfig.SCALE_025MM: QT_TRANSLATE_NOOP("protocols", "0.025mm/step"),
+        }
+        to_string = lambda v: QApplication.translate('protocols', labels[v])
+        items = list(labels.keys())
+        selected := model.unit_mode

--- a/inkcut/device/protocols/view.enaml
+++ b/inkcut/device/protocols/view.enaml
@@ -14,6 +14,7 @@ from enaml.core.api import Conditional
 from enaml.widgets.api import Container, Form, Label, ObjectCombo, SpinBox, MultilineField, CheckBox
 from enamlx.widgets.api import DoubleSpinBox
 from enaml.qt.QtWidgets import QApplication
+from enaml.qt.QtCore import QT_TRANSLATE_NOOP
 from .gcode import GCodeConfig
 
 enamldef DMPLConfigView(Container):
@@ -34,6 +35,16 @@ enamldef GCodeConfigView(Container):
             text = QApplication.translate("protocols", "Use builtin startup/end commands")
             checked := model.use_builtin
             tool_tip = QApplication.translate("protocols", "When disabled make sure to specify after connect, before and after job commands in device settings")
+        Label:
+            text = QApplication.translate("protocols", "Units")
+        ObjectCombo:
+            attr labels = {
+                GCodeConfig.UNIT_METRIC: QT_TRANSLATE_NOOP("protocols", "Metric: mm (G21)"),
+                GCodeConfig.UNIT_INCH: QT_TRANSLATE_NOOP("protocols", "Inch (G20)"),
+            }
+            to_string = lambda v: QApplication.translate('protocols', labels[v])
+            items = [GCodeConfig.UNIT_METRIC, GCodeConfig.UNIT_INCH]
+            selected := model.unit_mode
         Label:
             text = QApplication.translate("protocols", "Decimal precision")
         SpinBox:

--- a/inkcut/device/view.enaml
+++ b/inkcut/device/view.enaml
@@ -22,7 +22,7 @@ from enaml.widgets.api import (
 )
 from enamlx.widgets.api import DoubleSpinBox
 from inkcut.core.api import Model, DockItem
-from inkcut.core.utils import to_unit, load_icon
+from inkcut.core.utils import to_unit, from_unit, load_icon
 from inkcut.preview.plot_view import PlotView
 from .plugin import DeviceConfig
 
@@ -39,8 +39,36 @@ enamldef MatrixNumber(DoubleSpinBox):
     minimum = -10000000
     resist_width = 'weak'
 
+enamldef OffsetBox(Container): this:
+    padding = 0
+    constraints = [
+        hbox(x_label, v_x, y_label, v_y),
+        v_x.width == v_y.width,
+        align('v_center', x_label, v_x, y_label, v_y)
+    ]
+    alias v_x
+    alias v_y
+    attr suffix: str = ""
+    Label: x_label:
+        text = 'X:'
+    DoubleSpinBox: v_x:
+        #suffix << " "+plugin.units
+        suffix << this.suffix
+        minimum = -99999.9
+        maximum = 99999.9
+        single_step = 0.1
+    Label: y_label:
+        text = 'Y:'
+    DoubleSpinBox: v_y:
+        suffix << this.suffix
+        minimum = -99999.9
+        maximum = 99999.9
+        single_step = 0.1
+
 enamldef DeviceConfigView(Container):
     attr model: DeviceConfig
+    attr plugin
+    attr units << plugin.workbench.get_plugin("inkcut.job").units
     Notebook:
         tab_style = 'document'
         tab_position = 'left'
@@ -79,30 +107,6 @@ enamldef DeviceConfigView(Container):
             title = QApplication.translate("device", "Output")
             Form:
                 Label:
-                    text = QApplication.translate("device", "Orientation")
-                Container:
-                    constraints = [
-                        hbox(cbsxy, cbmx, cbmy, spacer),
-                        align('v_center', cbsxy, cbmx, cbmy)
-                    ]
-                    CheckBox: cbsxy:
-                        text = QApplication.translate("device", "Swap X/Y")
-                        checked := model.swap_xy
-                    CheckBox: cbmx:
-                        text = QApplication.translate("device", "Mirror X")
-                        checked := model.mirror_x
-                    CheckBox: cbmy:
-                        text = QApplication.translate("device", "Mirror Y")
-                        checked := model.mirror_y
-                #Label:
-                    #text = QApplication.translate("device", "Rotation")
-                #ObjectCombo:
-                    #items = list(model.get_member('rotation').items)
-                    #selected := model.rotation
-                    #tool_tip = textwrap.dedent("""
-                    #Final output rotation.
-                    #""").strip()
-                Label:
                     text = "x"
                 DoubleSpinBox:
                     value := model.scale[0]
@@ -139,33 +143,19 @@ enamldef DeviceConfigView(Container):
                             if item:
                                 model.axis_mapping = item[0]
                 Label:
-                    text = QApplication.translate("device", "Alignment corner")
-                ObjectCombo:
-                    items = list(model.get_member('area_alignment_corner').items)
-                    selected := model.area_alignment_corner
-                    attr labels = {
-                        DeviceConfig.ALIGNMENT_CORNER_ZERO: QT_TRANSLATE_NOOP("device", "Origin"),
-                        DeviceConfig.ALIGNMENT_CORNER_TOP_LEFT: QT_TRANSLATE_NOOP("device", "Top left"),
-                        DeviceConfig.ALIGNMENT_CORNER_TOP_RIGHT: QT_TRANSLATE_NOOP("device", "Top right"),
-                        DeviceConfig.ALIGNMENT_CORNER_BOTTOM_LEFT: QT_TRANSLATE_NOOP("device", "Bottom left"),
-                        DeviceConfig.ALIGNMENT_CORNER_BOTTOM_RIGHT: QT_TRANSLATE_NOOP("device", "Bottom right"),
-                    }
-                    to_string = lambda v: QApplication.translate('device', labels[v])
-                Conditional:
-                    condition << model.axis_mapping != DeviceConfig.AXIS_MAP_CUSTOM
-                    Label:
-                        text = QApplication.translate("device", "Extra scale")
-                        tool_tip = QApplication.translate("device", "Should only be used if device protocol lacks ability to negotiate scale, or implements the protocol incorrectly")
-                    DoubleSpinBox:
-                        decimals = 7
-                        single_step = 0.1
-                        maximum = 10000000
-                        value := model.extra_scale
+                    text = QApplication.translate("device", "Extra scale")
+                    tool_tip = QApplication.translate("device", "Should only be used if device protocol lacks ability to negotiate scale, or implements the protocol incorrectly")
+                DoubleSpinBox:
+                    decimals = 7
+                    single_step = 0.1
+                    maximum = 10000000
+                    value := model.extra_scale
                 Conditional:
                     condition << model.axis_mapping == DeviceConfig.AXIS_MAP_CUSTOM
                     Label:
                         text = QApplication.translate("device", "Custom mapping")
                     Container:
+                        padding = 0
                         constraints = [
                             grid(
                                 [None, lb_xt,  lb_yt, lb_offset],
@@ -197,7 +187,56 @@ enamldef DeviceConfigView(Container):
                             value := model.custom_mapping[4]
                         MatrixNumber: v_yc:
                             value := model.custom_mapping[5]
-
+                Label:
+                    pass
+                CheckBox: advanced_output_opt:
+                    text = QApplication.translate("device", "Advanced options")
+                Conditional:
+                    condition << advanced_output_opt.checked
+                    Label:
+                        text = QApplication.translate("device", "Work area quadrant")
+                    ObjectCombo:
+                        items = list(model.get_member('area_alignment_corner').items)
+                        selected := model.area_alignment_corner
+                        attr labels = {
+                            DeviceConfig.ALIGNMENT_CORNER_ZERO: QT_TRANSLATE_NOOP("device", "Positive"),
+                            DeviceConfig.ALIGNMENT_CORNER_TOP_LEFT: QT_TRANSLATE_NOOP("device", "Bottom right"),
+                            DeviceConfig.ALIGNMENT_CORNER_TOP_RIGHT: QT_TRANSLATE_NOOP("device", "Bottom left"),
+                            DeviceConfig.ALIGNMENT_CORNER_BOTTOM_LEFT: QT_TRANSLATE_NOOP("device", "Top right"),
+                            DeviceConfig.ALIGNMENT_CORNER_BOTTOM_RIGHT: QT_TRANSLATE_NOOP("device", "Top left"),
+                        }
+                        to_string = lambda v: QApplication.translate('device', labels[v])
+                    Label:
+                        text = QApplication.translate("device", "Work area offset")
+                    OffsetBox:
+                        enabled = True
+                        suffix << " " + units
+                        v_x.value << to_unit(model.work_area_offset.x, units)
+                        v_x.value ::  model.work_area_offset.x = from_unit(change['value'], units)
+                        v_y.value << to_unit(model.work_area_offset.y, units)
+                        v_y.value ::  model.work_area_offset.y = from_unit(change['value'], units)
+                    Label:
+                        text = QApplication.translate("device", "Paper alignment corner")
+                    ObjectCombo:
+                        items = list(model.get_member('paper_corner').items)
+                        selected := model.paper_corner
+                        attr labels = {
+                            DeviceConfig.ALIGNMENT_CORNER_ZERO: QT_TRANSLATE_NOOP("device", "Origin corner"),
+                            DeviceConfig.ALIGNMENT_CORNER_TOP_LEFT: QT_TRANSLATE_NOOP("device", "Top left"),
+                            DeviceConfig.ALIGNMENT_CORNER_TOP_RIGHT: QT_TRANSLATE_NOOP("device", "Top right"),
+                            DeviceConfig.ALIGNMENT_CORNER_BOTTOM_LEFT: QT_TRANSLATE_NOOP("device", "Bottom left"),
+                            DeviceConfig.ALIGNMENT_CORNER_BOTTOM_RIGHT: QT_TRANSLATE_NOOP("device", "Bottom right"),
+                        }
+                        to_string = lambda v: QApplication.translate('device', labels[v])
+                    Label:
+                        text = QApplication.translate("device", "Paper offset")
+                    OffsetBox:
+                        enabled = True
+                        suffix << " " + units
+                        v_x.value << to_unit(model.paper_offset.x, units)
+                        v_x.value ::  model.paper_offset.x = from_unit(change['value'], units)
+                        v_y.value << to_unit(model.paper_offset.y, units)
+                        v_y.value ::  model.paper_offset.y = from_unit(change['value'], units)
 
         Page:
             closable = False

--- a/inkcut/device/view.enaml
+++ b/inkcut/device/view.enaml
@@ -139,15 +139,16 @@ enamldef DeviceConfigView(Container):
                             if item:
                                 model.axis_mapping = item[0]
                 Label:
-                    text = QApplication.translate("device", "Paper roll position")
+                    text = QApplication.translate("device", "Alignment corner")
                 ObjectCombo:
-                    items = list(model.get_member('paper_roll').items)
-                    selected := model.paper_roll
+                    items = list(model.get_member('area_alignment_corner').items)
+                    selected := model.area_alignment_corner
                     attr labels = {
-                        DeviceConfig.PAPER_ROLL_AUTO: QT_TRANSLATE_NOOP("device", "Auto"),
-                        DeviceConfig.PAPER_ROLL_NONE: QT_TRANSLATE_NOOP("device", "None"),
-                        DeviceConfig.PAPER_ROLL_UP: QT_TRANSLATE_NOOP("device", "Up (behind)"),
-                        DeviceConfig.PAPER_ROLL_DOWN: QT_TRANSLATE_NOOP("device", "Down (front)"),
+                        DeviceConfig.ALIGNMENT_CORNER_ZERO: QT_TRANSLATE_NOOP("device", "Origin"),
+                        DeviceConfig.ALIGNMENT_CORNER_TOP_LEFT: QT_TRANSLATE_NOOP("device", "Top left"),
+                        DeviceConfig.ALIGNMENT_CORNER_TOP_RIGHT: QT_TRANSLATE_NOOP("device", "Top right"),
+                        DeviceConfig.ALIGNMENT_CORNER_BOTTOM_LEFT: QT_TRANSLATE_NOOP("device", "Bottom left"),
+                        DeviceConfig.ALIGNMENT_CORNER_BOTTOM_RIGHT: QT_TRANSLATE_NOOP("device", "Bottom right"),
                     }
                     to_string = lambda v: QApplication.translate('device', labels[v])
                 Conditional:

--- a/inkcut/device/view.enaml
+++ b/inkcut/device/view.enaml
@@ -12,8 +12,10 @@ Created on Dec 7, 2017
 """
 import os
 import textwrap
-from enaml.layout.api import hbox, vbox, spacer, align
+from enaml.layout.api import hbox, vbox, spacer, align, grid
+from enaml.core.api import Conditional
 from enaml.qt.QtWidgets import QApplication
+from enaml.qt.QtCore import QT_TRANSLATE_NOOP
 from enaml.widgets.api import (
     Form, CheckBox, Container, Label, ProgressBar, PushButton, Notebook, Page, ObjectCombo,
     Action, Menu, MultilineField
@@ -30,6 +32,12 @@ enamldef ConfigView(Container):
     Label:
         text = QApplication.translate("device", "No configuration available.")
 
+enamldef MatrixNumber(DoubleSpinBox):
+    decimals = 7
+    single_step = 0.1
+    maximum = 10000000
+    minimum = -10000000
+    resist_width = 'weak'
 
 enamldef DeviceConfigView(Container):
     attr model: DeviceConfig
@@ -95,34 +103,100 @@ enamldef DeviceConfigView(Container):
                     #Final output rotation.
                     #""").strip()
                 Label:
-                    text = QApplication.translate("device", "Scale")
-                Form:
-                    Label:
-                        text = "x"
-                    DoubleSpinBox:
-                        value := model.scale[0]
-                        decimals = 6
-                        minimum = -9999.9
-                        maximum = 9999.9
-                        tool_tip = textwrap.dedent("""
-                        Final output scale for the x-axis.
+                    text = "x"
+                DoubleSpinBox:
+                    value := model.scale[0]
+                    decimals = 6
+                    minimum = -9999.9
+                    maximum = 9999.9
+                    tool_tip = textwrap.dedent("""
+                    Final output scale for the x-axis.
+                    A value of '1' here means '90 points per inch'. For example:
+                    Suppose your device is 96 ppi, configure 96/90=1.06 here.
+                    Suppose your device is 200 points per cm, configure 200*2.54/90=5.64 here.
+                    """).strip()
+                Label:
+                    text = "y"
+                DoubleSpinBox:
+                    value := model.scale[1]
+                    decimals = 6
+                    minimum = -9999.9
+                    maximum = 9999.9
+                    tool_tip = textwrap.dedent("""
+                        Final output scale for the y-axis.
                         A value of '1' here means '90 points per inch'. For example:
                         Suppose your device is 96 ppi, configure 96/90=1.06 here.
                         Suppose your device is 200 points per cm, configure 200*2.54/90=5.64 here.
                         """).strip()
+                Label:
+                    text = QApplication.translate("device", "Axis mapping")
+                ObjectCombo: axis_mode:
+                    items  = list(DeviceConfig.AXIS_MAP_MODES.items())
+                    to_string = lambda obj: QApplication.translate("device_axis", obj[1])
+                    selected << (model.axis_mapping, DeviceConfig.AXIS_MAP_MODES[model.axis_mapping])
+                    selected ::
+                            item = change['value']
+                            if item:
+                                model.axis_mapping = item[0]
+                Label:
+                    text = QApplication.translate("device", "Paper roll position")
+                ObjectCombo:
+                    items = list(model.get_member('paper_roll').items)
+                    selected := model.paper_roll
+                    attr labels = {
+                        DeviceConfig.PAPER_ROLL_AUTO: QT_TRANSLATE_NOOP("device", "Auto"),
+                        DeviceConfig.PAPER_ROLL_NONE: QT_TRANSLATE_NOOP("device", "None"),
+                        DeviceConfig.PAPER_ROLL_UP: QT_TRANSLATE_NOOP("device", "Up (behind)"),
+                        DeviceConfig.PAPER_ROLL_DOWN: QT_TRANSLATE_NOOP("device", "Down (front)"),
+                    }
+                    to_string = lambda v: QApplication.translate('device', labels[v])
+                Conditional:
+                    condition << model.axis_mapping != DeviceConfig.AXIS_MAP_CUSTOM
                     Label:
-                        text = "y"
+                        text = QApplication.translate("device", "Extra scale")
+                        tool_tip = QApplication.translate("device", "Should only be used if device protocol lacks ability to negotiate scale, or implements the protocol incorrectly")
                     DoubleSpinBox:
-                        value := model.scale[1]
-                        decimals = 6
-                        minimum = -9999.9
-                        maximum = 9999.9
-                        tool_tip = textwrap.dedent("""
-                            Final output scale for the y-axis.
-                            A value of '1' here means '90 points per inch'. For example:
-                            Suppose your device is 96 ppi, configure 96/90=1.06 here.
-                            Suppose your device is 200 points per cm, configure 200*2.54/90=5.64 here.
-                            """).strip()
+                        decimals = 7
+                        single_step = 0.1
+                        maximum = 10000000
+                        value := model.extra_scale
+                Conditional:
+                    condition << model.axis_mapping == DeviceConfig.AXIS_MAP_CUSTOM
+                    Label:
+                        text = QApplication.translate("device", "Custom mapping")
+                    Container:
+                        constraints = [
+                            grid(
+                                [None, lb_xt,  lb_yt, lb_offset],
+                                [lb_xr, v_xx, v_xy, v_xc],
+                                [lb_yr, v_yx, v_yy, v_yc],
+                            ),
+                            v_xx.width == v_xy.width,
+                            v_xx.width == v_xc.width,
+                        ]
+                        Label: lb_xt:
+                            text = "X"
+                        Label: lb_yt:
+                            text = "Y"
+                        Label: lb_offset:
+                            text = "Offset"
+                        Label: lb_xr:
+                            text = "X"
+                        Label: lb_yr:
+                            text = "Y"
+                        MatrixNumber: v_xx:
+                            value := model.custom_mapping[0]
+                        MatrixNumber: v_xy:
+                            value := model.custom_mapping[1]
+                        MatrixNumber: v_xc:
+                            value := model.custom_mapping[2]
+                        MatrixNumber: v_yx:
+                            value := model.custom_mapping[3]
+                        MatrixNumber: v_yy:
+                            value := model.custom_mapping[4]
+                        MatrixNumber: v_yc:
+                            value := model.custom_mapping[5]
+
 
         Page:
             closable = False

--- a/inkcut/device/view.enaml
+++ b/inkcut/device/view.enaml
@@ -66,28 +66,6 @@ enamldef OffsetBox(Container): this:
         maximum = 99999.9
         single_step = 0.1
 
-def from_scale_mul(v, unit):
-    if unit == "step/in":
-        return v * from_unit(1, "in")
-    elif unit == "step/mm":
-        return v * from_unit(1, "mm")
-    elif unit == "mm/step":
-        return to_unit(1, "mm") / v
-    elif unit == "in/step":
-        return to_unit(1, "in") / v
-    return v
-
-def to_scale_mul(v, unit):
-    if unit == "step/in":
-        return to_unit(v, "in")
-    elif unit == "step/mm":
-        return to_unit(v, "mm")
-    elif unit == "mm/step":
-        return to_unit(1, "mm") / v
-    elif unit == "in/step":
-        return to_unit(1, "in") / v
-    return v
-
 enamldef AlignmentChoice9(Container): alignment_widget:
     padding = 0
     attr value = AreaBase.combine_alignment(AreaBase.JOB_AXIS_ALIGN_ZERO, AreaBase.JOB_AXIS_ALIGN_ZERO)
@@ -192,32 +170,6 @@ enamldef DeviceConfigView(Container):
             title = QApplication.translate("device", "Output")
             Form:
                 Label:
-                    text = "x"
-                DoubleSpinBox:
-                    value := model.scale[0]
-                    decimals = 6
-                    minimum = -9999.9
-                    maximum = 9999.9
-                    tool_tip = textwrap.dedent("""
-                    Final output scale for the x-axis.
-                    A value of '1' here means '90 points per inch'. For example:
-                    Suppose your device is 96 ppi, configure 96/90=1.06 here.
-                    Suppose your device is 200 points per cm, configure 200*2.54/90=5.64 here.
-                    """).strip()
-                Label:
-                    text = "y"
-                DoubleSpinBox:
-                    value := model.scale[1]
-                    decimals = 6
-                    minimum = -9999.9
-                    maximum = 9999.9
-                    tool_tip = textwrap.dedent("""
-                        Final output scale for the y-axis.
-                        A value of '1' here means '90 points per inch'. For example:
-                        Suppose your device is 96 ppi, configure 96/90=1.06 here.
-                        Suppose your device is 200 points per cm, configure 200*2.54/90=5.64 here.
-                        """).strip()
-                Label:
                     text = QApplication.translate("device", "Axis mapping")
                 ObjectCombo: axis_mode:
                     items  = list(DeviceConfig.AXIS_MAP_MODES.items())
@@ -229,7 +181,7 @@ enamldef DeviceConfigView(Container):
                                 model.axis_mapping = item[0]
                 Label: es_label:
                     text = QApplication.translate("device", "Extra scale")
-                    tool_tip = QApplication.translate("device", "Should only be used if device protocol lacks ability to negotiate scale, or implements the protocol incorrectly.")
+                    tool_tip = QApplication.translate("device", "Should only be used if device protocol lacks ability to negotiate or configure scale, implements the protocol incorrectly, or fine tuning exact scale.")
                 Container:
                     padding = 0
                     constraints = [
@@ -239,8 +191,8 @@ enamldef DeviceConfigView(Container):
                         decimals = 7
                         single_step = 0.1
                         maximum = 10000000
-                        value << from_scale_mul(model.extra_scale, es_unit.selected[0])
-                        value :: model.extra_scale = to_scale_mul(change['value'], es_unit.selected[0])
+                        value << DeviceConfig.from_scale_mul(model.extra_scale, es_unit.selected[0])
+                        value :: model.extra_scale = DeviceConfig.to_scale_mul(change['value'], es_unit.selected[0])
                         tool_tip << es_label.tool_tip
                     ObjectCombo: es_unit:
                         items << [

--- a/inkcut/device/view.enaml
+++ b/inkcut/device/view.enaml
@@ -65,6 +65,28 @@ enamldef OffsetBox(Container): this:
         maximum = 99999.9
         single_step = 0.1
 
+def from_scale_mul(v, unit):
+    if unit == "step/in":
+        return v * from_unit(1, "in")
+    elif unit == "step/mm":
+        return v * from_unit(1, "mm")
+    elif unit == "mm/step":
+        return to_unit(1, "mm") / v
+    elif unit == "in/step":
+        return to_unit(1, "in") / v
+    return v
+
+def to_scale_mul(v, unit):
+    if unit == "step/in":
+        return to_unit(v, "in")
+    elif unit == "step/mm":
+        return to_unit(v, "mm")
+    elif unit == "mm/step":
+        return to_unit(1, "mm") / v
+    elif unit == "in/step":
+        return to_unit(1, "in") / v
+    return v
+
 enamldef DeviceConfigView(Container):
     attr model: DeviceConfig
     attr plugin
@@ -142,14 +164,33 @@ enamldef DeviceConfigView(Container):
                             item = change['value']
                             if item:
                                 model.axis_mapping = item[0]
-                Label:
+                Label: es_label:
                     text = QApplication.translate("device", "Extra scale")
-                    tool_tip = QApplication.translate("device", "Should only be used if device protocol lacks ability to negotiate scale, or implements the protocol incorrectly")
-                DoubleSpinBox:
-                    decimals = 7
-                    single_step = 0.1
-                    maximum = 10000000
-                    value := model.extra_scale
+                    tool_tip = QApplication.translate("device", "Should only be used if device protocol lacks ability to negotiate scale, or implements the protocol incorrectly.")
+                Container:
+                    padding = 0
+                    constraints = [
+                        hbox(es, es_unit)
+                    ]
+                    DoubleSpinBox: es:
+                        decimals = 7
+                        single_step = 0.1
+                        maximum = 10000000
+                        value << from_scale_mul(model.extra_scale, es_unit.selected[0])
+                        value :: model.extra_scale = to_scale_mul(change['value'], es_unit.selected[0])
+                        tool_tip << es_label.tool_tip
+                    ObjectCombo: es_unit:
+                        items << [
+                            ("mul", QApplication.translate("device", "multiplier")),
+                            ("mm/step", QApplication.translate("device", "mm/step")),
+                            ("in/step", QApplication.translate("device", "in/step")),
+                            ("step/mm", QApplication.translate("device", "step/mm")),
+                            ("step/in", QApplication.translate("device", "step/in")),
+                        ]
+                        to_string = lambda v: v[1]
+                        tool_tip = QApplication.translate("device", "Display units for extra scale multiplier. Does"\
+                            "not affect units used for communicating with device. It is recommended to disable "\
+                            "protocol level scaling when using steps/in or mm/step here.")
                 Conditional:
                     condition << model.axis_mapping == DeviceConfig.AXIS_MAP_CUSTOM
                     Label:

--- a/inkcut/device/view.enaml
+++ b/inkcut/device/view.enaml
@@ -17,11 +17,12 @@ from enaml.core.api import Conditional
 from enaml.qt.QtWidgets import QApplication
 from enaml.qt.QtCore import QT_TRANSLATE_NOOP
 from enaml.widgets.api import (
-    Form, CheckBox, Container, Label, ProgressBar, PushButton, Notebook, Page, ObjectCombo,
-    Action, Menu, MultilineField
+    Form, CheckBox, Container, Label, ProgressBar, PushButton, RadioButton,
+    Notebook, Page, ObjectCombo, Action, Menu, MultilineField
 )
 from enamlx.widgets.api import DoubleSpinBox
 from inkcut.core.api import Model, DockItem
+from inkcut.core.models import AreaBase
 from inkcut.core.utils import to_unit, from_unit, load_icon
 from inkcut.preview.plot_view import PlotView
 from .plugin import DeviceConfig
@@ -86,6 +87,68 @@ def to_scale_mul(v, unit):
     elif unit == "in/step":
         return to_unit(1, "in") / v
     return v
+
+enamldef AlignmentChoice9(Container): alignment_widget:
+    padding = 0
+    attr value = AreaBase.combine_alignment(AreaBase.JOB_AXIS_ALIGN_ZERO, AreaBase.JOB_AXIS_ALIGN_ZERO)
+    Container:
+        constraints = [
+            hbox(h_o, h_n, h_m, h_p)
+        ]
+        padding = 0
+        RadioButton: h_o:
+            text = QApplication.translate("widget", "Origin")
+            clicked :: alignment_widget.value = AreaBase.combine_alignment(
+                AreaBase.JOB_AXIS_ALIGN_ZERO,
+                AreaBase.split_alignment(alignment_widget.value)[1])
+            checked << AreaBase.split_alignment(alignment_widget.value)[0] == AreaBase.JOB_AXIS_ALIGN_ZERO
+        RadioButton: h_n:
+            icon = load_icon('shape_align_left')
+            clicked :: alignment_widget.value = AreaBase.combine_alignment(
+                AreaBase.JOB_AXIS_ALIGN_MIN,
+                AreaBase.split_alignment(alignment_widget.value)[1])
+            checked << AreaBase.split_alignment(alignment_widget.value)[0] == AreaBase.JOB_AXIS_ALIGN_MIN
+        RadioButton: h_m:
+            icon = load_icon('shape_align_center')
+            clicked :: alignment_widget.value = AreaBase.combine_alignment(
+                AreaBase.JOB_AXIS_ALIGN_MID,
+                AreaBase.split_alignment(alignment_widget.value)[1])
+            checked << AreaBase.split_alignment(alignment_widget.value)[0] == AreaBase.JOB_AXIS_ALIGN_MID
+        RadioButton: h_p:
+            icon = load_icon('shape_align_right')
+            clicked :: alignment_widget.value = AreaBase.combine_alignment(
+                AreaBase.JOB_AXIS_ALIGN_MAX,
+                AreaBase.split_alignment(alignment_widget.value)[1])
+            checked << AreaBase.split_alignment(alignment_widget.value)[0] == AreaBase.JOB_AXIS_ALIGN_MAX
+    Container:
+        constraints = [
+            hbox(v_o, v_n, v_m, v_p)
+        ]
+        padding = 0
+        RadioButton: v_o:
+            text = QApplication.translate("widget", "Origin")
+            clicked :: alignment_widget.value = AreaBase.combine_alignment(
+                AreaBase.split_alignment(alignment_widget.value)[0],
+                AreaBase.JOB_AXIS_ALIGN_ZERO)
+            checked << AreaBase.split_alignment(alignment_widget.value)[1] == AreaBase.JOB_AXIS_ALIGN_ZERO
+        RadioButton: v_n:
+            icon = load_icon('shape_align_top')
+            clicked :: alignment_widget.value = AreaBase.combine_alignment(
+                AreaBase.split_alignment(alignment_widget.value)[0],
+                AreaBase.JOB_AXIS_ALIGN_MIN)
+            checked << AreaBase.split_alignment(alignment_widget.value)[1] == AreaBase.JOB_AXIS_ALIGN_MIN
+        RadioButton: v_m:
+            icon = load_icon('shape_align_middle')
+            clicked :: alignment_widget.value = AreaBase.combine_alignment(
+                AreaBase.split_alignment(alignment_widget.value)[0],
+                AreaBase.JOB_AXIS_ALIGN_MID)
+            checked << AreaBase.split_alignment(alignment_widget.value)[1] == AreaBase.JOB_AXIS_ALIGN_MID
+        RadioButton: v_p:
+            icon = load_icon('shape_align_bottom')
+            clicked :: alignment_widget.value = AreaBase.combine_alignment(
+                AreaBase.split_alignment(alignment_widget.value)[0],
+                AreaBase.JOB_AXIS_ALIGN_MAX)
+            checked << AreaBase.split_alignment(alignment_widget.value)[1] == AreaBase.JOB_AXIS_ALIGN_MAX
 
 enamldef DeviceConfigView(Container):
     attr model: DeviceConfig
@@ -232,6 +295,9 @@ enamldef DeviceConfigView(Container):
                     pass
                 CheckBox: advanced_output_opt:
                     text = QApplication.translate("device", "Advanced options")
+                    attr excl_icon = load_icon("exclamation")
+                    icon << excl_icon if (model.paper_corner != 0 or model.area_alignment_corner != DeviceConfig.ALIGNMENT_CORNER_ZERO\
+                        or model.work_area_offset.length() > 0.1 or model.paper_offset.length() > 0.1) else None
                 Conditional:
                     condition << advanced_output_opt.checked
                     Label:
@@ -241,10 +307,10 @@ enamldef DeviceConfigView(Container):
                         selected := model.area_alignment_corner
                         attr labels = {
                             DeviceConfig.ALIGNMENT_CORNER_ZERO: QT_TRANSLATE_NOOP("device", "Positive (default)"),
-                            DeviceConfig.ALIGNMENT_CORNER_TOP_LEFT: QT_TRANSLATE_NOOP("device", "Bottom right"),
-                            DeviceConfig.ALIGNMENT_CORNER_TOP_RIGHT: QT_TRANSLATE_NOOP("device", "Bottom left"),
                             DeviceConfig.ALIGNMENT_CORNER_BOTTOM_LEFT: QT_TRANSLATE_NOOP("device", "Top right"),
                             DeviceConfig.ALIGNMENT_CORNER_BOTTOM_RIGHT: QT_TRANSLATE_NOOP("device", "Top left"),
+                            DeviceConfig.ALIGNMENT_CORNER_TOP_RIGHT: QT_TRANSLATE_NOOP("device", "Bottom left"),
+                            DeviceConfig.ALIGNMENT_CORNER_TOP_LEFT: QT_TRANSLATE_NOOP("device", "Bottom right"),
                         }
                         to_string = lambda v: QApplication.translate('device', labels[v])
                     Label:
@@ -258,17 +324,8 @@ enamldef DeviceConfigView(Container):
                         v_y.value ::  model.work_area_offset.y = from_unit(change['value'], units)
                     Label:
                         text = QApplication.translate("device", "Paper alignment corner")
-                    ObjectCombo:
-                        items = list(model.get_member('paper_corner').items)
-                        selected := model.paper_corner
-                        attr labels = {
-                            DeviceConfig.ALIGNMENT_CORNER_ZERO: QT_TRANSLATE_NOOP("device", "Origin corner (default)"),
-                            DeviceConfig.ALIGNMENT_CORNER_TOP_LEFT: QT_TRANSLATE_NOOP("device", "Top left"),
-                            DeviceConfig.ALIGNMENT_CORNER_TOP_RIGHT: QT_TRANSLATE_NOOP("device", "Top right"),
-                            DeviceConfig.ALIGNMENT_CORNER_BOTTOM_LEFT: QT_TRANSLATE_NOOP("device", "Bottom left"),
-                            DeviceConfig.ALIGNMENT_CORNER_BOTTOM_RIGHT: QT_TRANSLATE_NOOP("device", "Bottom right"),
-                        }
-                        to_string = lambda v: QApplication.translate('device', labels[v])
+                    AlignmentChoice9:
+                        value := model.paper_corner
                     Label:
                         text = QApplication.translate("device", "Paper offset")
                     OffsetBox:

--- a/inkcut/device/view.enaml
+++ b/inkcut/device/view.enaml
@@ -199,7 +199,7 @@ enamldef DeviceConfigView(Container):
                         items = list(model.get_member('area_alignment_corner').items)
                         selected := model.area_alignment_corner
                         attr labels = {
-                            DeviceConfig.ALIGNMENT_CORNER_ZERO: QT_TRANSLATE_NOOP("device", "Positive"),
+                            DeviceConfig.ALIGNMENT_CORNER_ZERO: QT_TRANSLATE_NOOP("device", "Positive (default)"),
                             DeviceConfig.ALIGNMENT_CORNER_TOP_LEFT: QT_TRANSLATE_NOOP("device", "Bottom right"),
                             DeviceConfig.ALIGNMENT_CORNER_TOP_RIGHT: QT_TRANSLATE_NOOP("device", "Bottom left"),
                             DeviceConfig.ALIGNMENT_CORNER_BOTTOM_LEFT: QT_TRANSLATE_NOOP("device", "Top right"),
@@ -221,7 +221,7 @@ enamldef DeviceConfigView(Container):
                         items = list(model.get_member('paper_corner').items)
                         selected := model.paper_corner
                         attr labels = {
-                            DeviceConfig.ALIGNMENT_CORNER_ZERO: QT_TRANSLATE_NOOP("device", "Origin corner"),
+                            DeviceConfig.ALIGNMENT_CORNER_ZERO: QT_TRANSLATE_NOOP("device", "Origin corner (default)"),
                             DeviceConfig.ALIGNMENT_CORNER_TOP_LEFT: QT_TRANSLATE_NOOP("device", "Top left"),
                             DeviceConfig.ALIGNMENT_CORNER_TOP_RIGHT: QT_TRANSLATE_NOOP("device", "Top right"),
                             DeviceConfig.ALIGNMENT_CORNER_BOTTOM_LEFT: QT_TRANSLATE_NOOP("device", "Bottom left"),

--- a/inkcut/device/view.enaml
+++ b/inkcut/device/view.enaml
@@ -379,7 +379,7 @@ enamldef DeviceProgressDockItem(DockItem):
                     triggered :: plot.proxy.widget.autoRange()
                 Action:
                     text = QApplication.translate("device", "Clear plot")
-                    triggered :: plugin.reset_preview()
+                    triggered :: preview_plugin.reset_live_preview(device, job, True)
         Container:
             constraints = [
                 vbox(

--- a/inkcut/job/models.py
+++ b/inkcut/job/models.py
@@ -222,7 +222,6 @@ class Job(Model):
     _desired_copies = Int(1)  # required for auto copies
 
     quadrant_direction = Instance(QPointF)
-    page_direction = Instance(QPointF)
 
     def __str__(self):
         source = self.document
@@ -292,9 +291,6 @@ class Job(Model):
         return doc
 
     def _default_content_direction(self):
-        return QPointF(1, 1)
-
-    def _default_page_direction(self):
         return QPointF(1, 1)
 
     @observe('path', 'order', 'filters')
@@ -456,9 +452,10 @@ class Job(Model):
         page_area = self.material.get_content_rect(self.quadrant_direction)
 
         # TODO: add UI option for aligning to any corner
-        t_align = self.align_rect_to_rect(bbox, page_area,
-                                          Job.JOB_AXIS_ALIGN_MID if self.align_center[0] else Job.JOB_AXIS_ALIGN_ZERO,
-                                          Job.JOB_AXIS_ALIGN_MID if self.align_center[1] else Job.JOB_AXIS_ALIGN_ZERO)
+        t_align = AreaBase.align_rect_to_rect(bbox, page_area,
+                                          AreaBase.JOB_AXIS_ALIGN_MID if self.align_center[0] else AreaBase.JOB_AXIS_ALIGN_ZERO,
+                                          AreaBase.JOB_AXIS_ALIGN_MID if self.align_center[1] else AreaBase.JOB_AXIS_ALIGN_ZERO,
+                                          self.quadrant_direction)
 
         model:QPainterPath = t_align.map(model)
 
@@ -482,29 +479,6 @@ class Job(Model):
             model.moveTo(end_point)
 
         return model
-
-    @staticmethod
-    def align_axis(o1: float, o2: float, b1: float, b2: float, side: int) -> float:
-        if side == Job.JOB_AXIS_ALIGN_MIN:
-            return b1 - o1
-        if side == Job.JOB_AXIS_ALIGN_MAX:
-            return b2 - o2
-        return (b1 + b2) / 2 - (o1 + o2) / 2
-
-    JOB_AXIS_ALIGN_MIN = -1
-    JOB_AXIS_ALIGN_MAX = 1
-    JOB_AXIS_ALIGN_MID = 0
-    JOB_AXIS_ALIGN_ZERO = 2
-
-    def align_rect_to_rect(self, from_rect: QRectF, to_rect: QRectF, align_x, align_y) -> QTransform:
-        if align_x == Job.JOB_AXIS_ALIGN_ZERO:
-            align_x = 1 if self.quadrant_direction.x() < 0 else -1
-        if align_y == Job.JOB_AXIS_ALIGN_ZERO:
-            align_y = 1 if self.quadrant_direction.y() < 0 else -1
-
-        dx = Job.align_axis(from_rect.left(), from_rect.right(), to_rect.left(), to_rect.right(), align_x)
-        dy = Job.align_axis(from_rect.top(), from_rect.bottom(), to_rect.top(), to_rect.bottom(), align_y)
-        return QTransform.fromTranslate(dx, dy)
 
     def _check_bounds(self, plot, area):
         """ Checks that the width and height of plot are less than the width
@@ -578,10 +552,8 @@ class Job(Model):
     def state(self):
         pass
 
-    def set_direction(self, direction: QPointF, page_corner_direction: QPointF):
+    def set_direction(self, direction: QPointF):
         self.quadrant_direction = direction
-        self.page_direction = page_corner_direction
-
     @property
     def move_path(self):
         """ Returns the path the head moves when not cutting

--- a/inkcut/job/models.py
+++ b/inkcut/job/models.py
@@ -324,7 +324,7 @@ class Job(Model):
         t.scale(
             self.scale[0] * (self.mirror[0] and -1 or 1),
             self.scale[1] * (self.mirror[1] and -1 or 1),
-            )
+        )
 
         bbox_c = t.mapRect(bbox)
 
@@ -364,7 +364,6 @@ class Job(Model):
                 t = QTransform.fromScale(s, s)
                 path = t.map(optimized_path)
                 bbox = t.mapRect(bbox)
-
 
         return bbox, path
 
@@ -443,7 +442,7 @@ class Job(Model):
             model.addPath(copy_transform.map(path))
             c += 1
 
-        bbox:QRectF = combined_box
+        bbox: QRectF = combined_box
 
         # Create weedline
         if self.plot_weedline:
@@ -453,11 +452,13 @@ class Job(Model):
 
         # TODO: add UI option for aligning to any corner
         t_align = AreaBase.align_rect_to_rect(bbox, page_area,
-                                          AreaBase.JOB_AXIS_ALIGN_MID if self.align_center[0] else AreaBase.JOB_AXIS_ALIGN_ZERO,
-                                          AreaBase.JOB_AXIS_ALIGN_MID if self.align_center[1] else AreaBase.JOB_AXIS_ALIGN_ZERO,
-                                          self.quadrant_direction)
+                                              AreaBase.JOB_AXIS_ALIGN_MID if self.align_center[
+                                                  0] else AreaBase.JOB_AXIS_ALIGN_ZERO,
+                                              AreaBase.JOB_AXIS_ALIGN_MID if self.align_center[
+                                                  1] else AreaBase.JOB_AXIS_ALIGN_ZERO,
+                                              self.quadrant_direction)
 
-        model:QPainterPath = t_align.map(model)
+        model: QPainterPath = t_align.map(model)
 
         final_bounds = model.boundingRect()
 
@@ -491,7 +492,7 @@ class Job(Model):
         """ Generator that creates positions of points
 
         """
-        other_axis = axis +1 % 2
+        other_axis = axis + 1 % 2
         direction = (direction.x(), direction.y())
         anchor = [0, 0]
         p = [0, 0]
@@ -509,11 +510,11 @@ class Job(Model):
             p[axis] = anchor[axis]
             yield p  # Beginning of each row
 
-            for i in range(stack_size[axis]-1):
-                p[axis] += (d[axis]+pad[axis]) * direction[axis]
+            for i in range(stack_size[axis] - 1):
+                p[axis] += (d[axis] + pad[axis]) * direction[axis]
                 yield p
 
-            p[other_axis] += (d[other_axis]+pad[other_axis]) * direction[other_axis]
+            p[other_axis] += (d[other_axis] + pad[other_axis]) * direction[other_axis]
 
     def _compute_stack_sizes(self, path, bbox):
         # Usable area
@@ -529,7 +530,7 @@ class Job(Model):
         p = [0, 0]
         for i in range(2):
             # Compute stack
-            while (p[i]+size[i]) < a[i]:  # while another one fits
+            while (p[i] + size[i]) < a[i]:  # while another one fits
                 stack_size[i] += 1
                 p[i] += size[i] + self.copy_spacing[i]  # Add only to end
 
@@ -541,7 +542,8 @@ class Job(Model):
         by creating a box around the path with the given padding
 
         """
-        bbox = bbox.adjusted(-padding[Padding.LEFT], -padding[Padding.TOP], padding[Padding.RIGHT], padding[Padding.BOTTOM])
+        bbox = bbox.adjusted(-padding[Padding.LEFT], -padding[Padding.TOP],
+                             padding[Padding.RIGHT], padding[Padding.BOTTOM])
 
         path.addRect(bbox)
         transform = AreaBase.rect_to_corner(bbox, self.quadrant_direction)
@@ -554,6 +556,7 @@ class Job(Model):
 
     def set_direction(self, direction: QPointF):
         self.quadrant_direction = direction
+
     @property
     def move_path(self):
         """ Returns the path the head moves when not cutting

--- a/inkcut/job/plugin.py
+++ b/inkcut/job/plugin.py
@@ -16,6 +16,7 @@ from atom.api import Instance, Enum, List, Str, Int, Float, observe
 from inkcut.core.api import Plugin, unit_conversions, log
 
 from .models import Job, JobError, Material
+from ..preview.plugin import PreviewPlugin
 
 with enaml.imports():
     from enaml.workbench.ui.workbench_menus import WorkbenchMenu
@@ -184,7 +185,7 @@ class JobPlugin(Plugin):
         view_items = []
 
         #: Transform used by the view
-        preview_plugin = self.workbench.get_plugin("inkcut.preview")
+        preview_plugin: PreviewPlugin = self.workbench.get_plugin("inkcut.preview")
         job = self.job
         plot = preview_plugin.preview
         t = preview_plugin.transform
@@ -194,7 +195,7 @@ class JobPlugin(Plugin):
         device = plugin.device
 
         #: Apply the final output transforms from the device
-        transform = device.transform if device else lambda p: p
+        transform = lambda p: p #TODO: cleanup
 
         if device and device.area:
             area = device.area

--- a/inkcut/job/plugin.py
+++ b/inkcut/job/plugin.py
@@ -198,8 +198,7 @@ class JobPlugin(Plugin):
         plugin = self.workbench.get_plugin("inkcut.device")
         device = plugin.device
         device_config:DeviceConfig = device.config
-        job.set_direction(device_config.expansion_direction,
-                          device_config.page_placement_direction)
+        job.set_direction(device_config.expansion_direction)
 
         #: Apply the final output transforms from the device
         page_transform = QTransform()

--- a/inkcut/job/plugin.py
+++ b/inkcut/job/plugin.py
@@ -21,7 +21,6 @@ from .models import Job, JobError, Material
 from ..core import utils
 from ..core.models import AreaBase
 from ..device.plugin import DeviceConfig
-from ..preview.plugin import PreviewPlugin
 
 with enaml.imports():
     from enaml.workbench.ui.workbench_menus import WorkbenchMenu
@@ -190,7 +189,7 @@ class JobPlugin(Plugin):
         view_items = []
 
         #: Transform used by the view
-        preview_plugin: PreviewPlugin = self.workbench.get_plugin("inkcut.preview")
+        preview_plugin = self.workbench.get_plugin("inkcut.preview")
         job = self.job
         plot = preview_plugin.preview
         t = preview_plugin.transform

--- a/inkcut/job/plugin.py
+++ b/inkcut/job/plugin.py
@@ -197,7 +197,7 @@ class JobPlugin(Plugin):
         #: Draw the device
         plugin = self.workbench.get_plugin("inkcut.device")
         device = plugin.device
-        device_config:DeviceConfig = device.config
+        device_config: DeviceConfig = device.config
         job.set_direction(device_config.expansion_direction)
 
         #: Apply the final output transforms from the device

--- a/inkcut/job/view.enaml
+++ b/inkcut/job/view.enaml
@@ -524,9 +524,11 @@ enamldef MaterialDockItem(DockItem):
             Conditional: feed_group:
                 condition << (feed_choice.selected != Job.FEED_MOVE_TO_0) and (feed_choice.selected != Job.FEED_NOTHING)
                 Container: feed_param:
+                    padding = 0
                     constraints = [
                         hbox(feed_x_label, fd_x, feed_y_label, fd_y),
-                        fd_x.width == fd_y.width
+                        fd_x.width == fd_y.width,
+                        align('v_center', feed_x_label, fd_x, feed_y_label, fd_y)
                     ]
                     Label: feed_x_label:
                         visible << feed_choice.selected != 'feed_to_end'

--- a/inkcut/job/view.enaml
+++ b/inkcut/job/view.enaml
@@ -495,8 +495,8 @@ enamldef MaterialDockItem(DockItem):
             Label:
                 text = QApplication.translate("job", "Plot Alignment")
             CheckBox:
-                text = QApplication.translate("job", 'Shift to origin')
-                icon = load_icon('shape_align_left')
+                text = QApplication.translate("job", 'Use content bounds')
+                icon = load_icon('page_white_picture')
                 checked := job.auto_shift
             CheckBox:
                 text = QApplication.translate("job", 'Align center horizontally')

--- a/inkcut/job/view.enaml
+++ b/inkcut/job/view.enaml
@@ -19,6 +19,7 @@ from enaml.widgets.api import (
 )
 from enaml.core.api import Looper, Conditional
 from enaml.layout.api import hbox, vbox, spacer, align
+from enaml.qt.QtCore import QT_TRANSLATE_NOOP
 from enaml.qt.QtWidgets import QApplication
 from enamlx.widgets.api import (
     DoubleSpinBox, TableView, TableViewRow, TableViewItem
@@ -507,26 +508,44 @@ enamldef MaterialDockItem(DockItem):
                 checked := job.align_center[1]
         Container:
             padding = 0
-            constraints = [
-                vbox(lbl,
-                     rb1,
-                     hbox(rb2,dsb)),
-                align('v_center',rb2,dsb)
-            ]
             Label: lbl:
                 text = QApplication.translate("job", "Plot Feeding")
-            RadioButton: rb1:
-                text = QApplication.translate("job", "Return to origin")
-                checked << not job.feed_to_end
-            RadioButton: rb2:
-                text = QApplication.translate("job", "Feed after")
-                checked := job.feed_to_end
-            DoubleSpinBox: dsb:
-                value << to_unit(job.feed_after, plugin.units)
-                value :: job.feed_after = from_unit(change['value'],plugin.units)
-                suffix << " "+plugin.units
-                maximum = 99999.9
-                single_step = 0.1
+            ObjectCombo: feed_choice:
+                items = list(job.get_member('after_job').items)
+                selected := job.after_job
+                attr labels = {
+                    Job.FEED_MOVE_TO_0: QT_TRANSLATE_NOOP("job", "Return to origin"),
+                    Job.FEED_TO_END: QT_TRANSLATE_NOOP("job", "Feed after and shift origin"),
+                    Job.FEED_WITHOUT_SHIFT: QT_TRANSLATE_NOOP("job", "Feed only"),
+                    Job.FEED_MOVE_TO: QT_TRANSLATE_NOOP("job", "Move to position"),
+                    Job.FEED_NOTHING: QT_TRANSLATE_NOOP("job", "Nothing"),
+                }
+                to_string = lambda v: QApplication.translate('job_after', labels[v])
+            Conditional: feed_group:
+                condition << (feed_choice.selected != Job.FEED_MOVE_TO_0) and (feed_choice.selected != Job.FEED_NOTHING)
+                Container: feed_param:
+                    constraints = [
+                        hbox(feed_x_label, fd_x, feed_y_label, fd_y),
+                        fd_x.width == fd_y.width
+                    ]
+                    Label: feed_x_label:
+                        visible << feed_choice.selected != 'feed_to_end'
+                        text = 'X:'
+                    DoubleSpinBox: fd_x:
+                        visible << feed_choice.selected != 'feed_to_end'
+                        value << to_unit(job.final_position[0], plugin.units)
+                        value :: job.final_position[0] = from_unit(change['value'],plugin.units)
+                        suffix << " "+plugin.units
+                        maximum = 99999.9
+                        single_step = 0.1
+                    Label: feed_y_label:
+                        text = 'Y:'
+                    DoubleSpinBox: fd_y:
+                        value << to_unit(job.final_position[1], plugin.units)
+                        value :: job.final_position[1] = from_unit(change['value'],plugin.units)
+                        suffix << " "+plugin.units
+                        maximum = 99999.9
+                        single_step = 0.1
 
 
 enamldef JobHistoryDockItem(DockItem):

--- a/inkcut/job/view.enaml
+++ b/inkcut/job/view.enaml
@@ -498,6 +498,8 @@ enamldef MaterialDockItem(DockItem):
                 text = QApplication.translate("job", 'Use content bounds')
                 icon = load_icon('page_white_picture')
                 checked := job.auto_shift
+                tool_tip =  QApplication.translate("job", """Whether to use the dimensions of filtered input document
+                 content or whole page for positioning. Disable for easier alignment of multiple passes.""")
             CheckBox:
                 text = QApplication.translate("job", 'Align center horizontally')
                 icon = load_icon('shape_align_center')

--- a/inkcut/joystick/plugin.py
+++ b/inkcut/joystick/plugin.py
@@ -93,7 +93,7 @@ class JoystickPlugin(Plugin):
 
     @with_connection
     def move_up(self):
-        self.device.move([0, - self.rate, 0], absolute=False)
+        self.device.move([0, -self.rate, 0], absolute=False)
 
     @with_connection
     def move_down(self):

--- a/inkcut/joystick/plugin.py
+++ b/inkcut/joystick/plugin.py
@@ -11,7 +11,7 @@ Created on Jul 19, 2015
 @author: jrm
 """
 import functools
-from atom.api import Instance, Int, observe
+from atom.api import Instance, Float, observe
 from enaml.qt import QtCore, QtGui
 from twisted.internet import defer
 
@@ -43,7 +43,7 @@ class JoystickPlugin(Plugin):
     device = Instance(Device)
 
     #: Rate to move
-    rate = Int(100).tag(config=True)
+    rate = Float(1).tag(config=True)
     path = Instance(QtGui.QPainterPath)
 
     #: Reference to the device plugin
@@ -83,35 +83,34 @@ class JoystickPlugin(Plugin):
 
     @with_connection
     def move_to_origin(self, system=False):
-        x, y, z = [0, 0, 0] if system else self.device.origin
+        if system:
+            x, y = 0, 0
+        else:
+            origin = self.device.origin
+            pos = self.device.config.inverse_transform.map_point(QtCore.QPointF(origin.x(), origin.y()))
+            x, y = pos.x(), pos.y()
         self.device.move([x, y, 0], absolute=True)
 
     @with_connection
     def move_up(self):
-        x, y, z = self.device.position
-        self.device.move([x, y+self.rate, z], absolute=True)
+        self.device.move([0, - self.rate, 0], absolute=False)
 
     @with_connection
     def move_down(self):
-        x, y, z = self.device.position
-        self.device.move([x, y-self.rate, z], absolute=True)
+        self.device.move([0, self.rate, 0], absolute=False)
 
     @with_connection
     def move_left(self):
-        x, y, z = self.device.position
-        self.device.move([x-self.rate, y, z], absolute=True)
+        self.device.move([-self.rate, 0, 0], absolute=False)
 
     @with_connection
     def move_right(self):
-        x, y, z = self.device.position
-        self.device.move([x+self.rate, y, z], absolute=True)
+        self.device.move([self.rate, 0, 0], absolute=False)
 
     @with_connection
     def move_head_up(self):
-        x, y, z = self.device.position
-        self.device.move([x, y, 0], absolute=True)
+        self.device.move([0, 0, 0], absolute=False)
 
     @with_connection
     def move_head_down(self):
-        x, y, z = self.device.position
-        self.device.move([x, y, 1], absolute=True)
+        self.device.move([0, 0, 1], absolute=False)

--- a/inkcut/joystick/view.enaml
+++ b/inkcut/joystick/view.enaml
@@ -19,8 +19,8 @@ from enaml.widgets.api import (CheckBox, Container, Dialog, Field, Label,
     ImageView, PushButton, RadioButton, Window,ProgressBar, Form, ObjectCombo)
 
 from enaml.widgets.spin_box import SpinBox
-from enamlx.widgets.api import KeyEvent
-from inkcut.core.api import DockItem, to_unit
+from enamlx.widgets.api import DoubleSpinBox, KeyEvent
+from inkcut.core.api import DockItem, to_unit, from_unit
 from inkcut.core.utils import load_icon
 
 
@@ -30,6 +30,7 @@ enamldef JoystickDockItem(DockItem): joystickDock:
     attr plugin
     attr device << plugin.device
     attr device_plugin << plugin.workbench.get_plugin('inkcut.device')
+    attr job_plugin << plugin.workbench.get_plugin('inkcut.job')
     icon = load_icon('controller')
 
     attr pending_refresh = False 
@@ -94,10 +95,12 @@ enamldef JoystickDockItem(DockItem): joystickDock:
 
                 Label:
                     text = QApplication.translate('control', 'Step')
-                SpinBox:
+                DoubleSpinBox:
                     maximum = 1000000000
-                    single_step = 10
-                    value := plugin.rate
+                    decimals = 3
+                    suffix << " " + job_plugin.units
+                    value << to_unit(plugin.rate, job_plugin.units)
+                    value :: plugin.rate = from_unit(change['value'], job_plugin.units)
                 Label:
                     text = QApplication.translate('control', "Status")
                 Label: status_label:

--- a/inkcut/preview/plugin.py
+++ b/inkcut/preview/plugin.py
@@ -124,7 +124,6 @@ class PreviewPlugin(Plugin):
             A list of kwargs to to pass to each plot item
 
         """
-        t = self.transform
         view_items = [
             PainterPathPlotItem(kwargs.pop('path'), **kwargs)
             for kwargs in items

--- a/inkcut/preview/plugin.py
+++ b/inkcut/preview/plugin.py
@@ -84,12 +84,12 @@ class PreviewModel(Model):
             return
         x, y, z = position
         if z:
-            self.paths[0].lineTo(x, -y)
-            self.paths[1].moveTo(x, -y)
+            self.paths[0].lineTo(x, y)
+            self.paths[1].moveTo(x, y)
             self.queue_redraw(0)
         else:
-            self.paths[0].moveTo(x, -y)
-            self.paths[1].lineTo(x, -y)
+            self.paths[0].moveTo(x, y)
+            self.paths[1].lineTo(x, y)
             self.queue_redraw(1)
 
 

--- a/inkcut/preview/plugin.py
+++ b/inkcut/preview/plugin.py
@@ -13,9 +13,10 @@ import pyqtgraph as pg
 from atom.api import List, Instance, Enum, Bool, Range, Int
 from enaml.application import timed_call
 from enaml.qt import QtCore, QtGui
+from enaml.qt.QtCore import QPointF
 from inkcut.core.api import Plugin, Model, unit_conversions, log
 from .plot_view import PainterPathPlotItem
-
+from ..core import utils
 
 QPen = QtGui.QPen
 
@@ -55,9 +56,10 @@ class PreviewModel(Model):
     def _default_pen_down(self):
         return pg.mkPen((128, 128, 128))
 
-    def init(self, view_items):
+    def init(self, view_items, clear_main_paths=True):
         default_items = []
-        self.paths = [QtGui.QPainterPath(), QtGui.QPainterPath()]
+        if clear_main_paths or not self.paths:
+            self.paths = [QtGui.QPainterPath(), QtGui.QPainterPath()]
 
         default_items.append(PainterPathPlotItem(
             self.paths[0], pen=self.pen_down))
@@ -130,7 +132,7 @@ class PreviewPlugin(Plugin):
         ]
         self.preview.plot = view_items
 
-    def set_live_preview(self, *items):
+    def set_live_preview(self, *items, clear_paths=True):
         """ Set the items that will be displayed in the live plot preview.
         After set, use live_preview.update(position) to update it.
 
@@ -145,5 +147,43 @@ class PreviewPlugin(Plugin):
             PainterPathPlotItem(kwargs.pop('path'), **kwargs)
             for kwargs in items
         ]
-        self.live_preview.init(view_items)
+        self.live_preview.init(view_items, clear_main_paths=clear_paths)
 
+    def reset_live_preview(self, device, job, clear_paths=True):
+        """ Redraw the live preview on the screen
+
+                """
+        view_items = []
+
+        if job:
+            job.set_direction(device.config.expansion_direction,
+                              device.config.page_placement_direction)
+
+        #: Transform used by the view
+        plot = self.live_preview
+
+        #: Draw the device
+        if device:
+            view_items.append(
+                dict(path=utils.rect_to_path(device.area_rect),
+                     pen=plot.pen_device,
+                     skip_autorange=True)
+            )
+
+        if job and job.material:
+            # Also observe any change to job.media and job.device
+            page_rect = job.material.get_rect(job.quadrant_direction)
+            padded_page = job.material.get_content_rect(job.quadrant_direction)
+            t = device.config.get_paper_to_work_transform(job.material)
+            origin = device.config.inverse_transform.map(QPointF(device.origin[0], device.origin[1]))
+            t.translate(origin.x(), origin.y())
+            view_items.extend([
+                dict(path=utils.rect_to_path(t.mapRect(page_rect)),
+                     pen=plot.pen_media,
+                     skip_autorange=True),
+                dict(path=utils.rect_to_path(t.mapRect(padded_page)),
+                     pen=plot.pen_media_padding, skip_autorange=True)
+            ])
+
+        #: Update the plot
+        self.set_live_preview(*view_items, clear_paths=clear_paths)

--- a/inkcut/preview/plugin.py
+++ b/inkcut/preview/plugin.py
@@ -156,8 +156,7 @@ class PreviewPlugin(Plugin):
         view_items = []
 
         if job:
-            job.set_direction(device.config.expansion_direction,
-                              device.config.page_placement_direction)
+            job.set_direction(device.config.expansion_direction)
 
         #: Transform used by the view
         plot = self.live_preview

--- a/tests/protocols/test_gcode_stream.py
+++ b/tests/protocols/test_gcode_stream.py
@@ -25,6 +25,7 @@ from inkcut.device.protocols.gcode import GCodeConfig, GCodeProtocol
 def gcodedevice_fixture():
     config = DeviceConfig()
     config.test_mode = True
+    config.axis_mapping = DeviceConfig.AXIS_MAP_XR_YD
     decl = DeviceDriver()
     dev = Device(config=config, declaration=decl)
     gcode_config = GCodeConfig()

--- a/tests/protocols/test_gcode_stream.py
+++ b/tests/protocols/test_gcode_stream.py
@@ -15,7 +15,7 @@ import pytest
 
 from twisted.internet import task, defer
 
-
+from inkcut.core import utils
 from inkcut.device.plugin import DeviceConfig, Device, TestTransport
 from inkcut.device.extensions import DeviceDriver
 from inkcut.device.protocols.gcode import GCodeConfig, GCodeProtocol
@@ -46,6 +46,8 @@ def test_ok_streaming(gcodedevice_fixture):
 
     transport: TestTransport = gcodedevice_fixture.connection
 
+    mm = utils.from_unit(1, "mm")
+
     connect_r = defer.maybeDeferred(gcodedevice_fixture.connect)
     # connect_r.addCallback(finish, 1)
     # clock.callLater(0, connect_r)
@@ -53,7 +55,7 @@ def test_ok_streaming(gcodedevice_fixture):
     assert connect_r.called
 
     # wait for ok to finish
-    move1_def = defer.maybeDeferred(gcodedevice_fixture.move, (1, 1, 0))
+    move1_def = defer.maybeDeferred(gcodedevice_fixture.move, (1 * mm, 1 * mm, 0))
     assert move1_def.called is False
     clock.pump([0.01] * 10)
     assert move1_def.called is False
@@ -64,7 +66,7 @@ def test_ok_streaming(gcodedevice_fixture):
     transport.clear_buffer()
 
     # multipart receive
-    move1_def = defer.maybeDeferred(gcodedevice_fixture.move, (1, 2, 0))
+    move1_def = defer.maybeDeferred(gcodedevice_fixture.move, (1 * mm, 2 * mm, 0))
     assert move1_def.called is False
     clock.pump([0.01] * 10)
     assert move1_def.called is False


### PR DESCRIPTION
TODO:
* [x] restore live preview funcitonality
* [x] protocol level scale config for all protocols
    - [x]  camm
    - [x] debug
    - [x] dmpl
    - [x] gcode (G20 G21)
    - [x] gpgl
    - [x] hpgl
* [x] migrate existing devices
* [x] cleanup old properties

Closes: #5, #3

* introduce new paper feed options after the print is done (advance without changing origin, move to position, do nothing)
* rework how scale and axis direction is configured 
   * handle final scale at protocol level where possible
   * hopefully easier to understand axis configuration which doesn't depend on knowing which is normal and which is inverted axis direction
   * allow choosing which working area corner is used for aligning pages of various size
   * support negative coordinate space (most device coordinate spaces are organized with paper in positive quadrant, but there are always exceptions of some devices doing weird stuff)
   * better handling of internal transformations for supporting infinite size paper while minimizing floating point errors and avoiding bad placement order. Ensure copies are always placed along the paper roll axis from 0 in the increasing direction.
   * fix some cases of  incorrect reported or drawn size when scale isn't 1
   * better handling original positions relative to page (important for doing multilayer plots with multiple pens), upstream had recently added it, but it was acting a bit buggy
   * preparations for running the filters at working scale #32
   * user friendlier input methods for custom scale (step/in, steps/mm, in/step, mm/step) 
   * Hopefully simplify future code by ensuring most calculations happen in a coordinate space which is (almost) unaffected by final device axis orientation and scale. Do the device coordinate transformation as late as possible. Biggest exception to this is working quadrant and copy placement direction,  those are chosen to perform calculations  near 0 where floating point has most precision. 
   
Followup tasks:
* #34
* #32
* #30 
* #37